### PR TITLE
chore: scrub internal references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 A local service that puts the **Comfy API v2** in front of a self-hosted ComfyUI
 instance, so the same SDK code that talks to Comfy Cloud also drives a ComfyUI on
-your own machine. One of the three surfaces in `docs/sdk/plan.md` (alongside Comfy
-Cloud's `public-api` and the serverless gateway).
+your own machine.
 
 Python + aiohttp — the same stack as ComfyUI core, so the adapter can later move
 into core itself.
@@ -27,7 +26,7 @@ python demo/run_demo.py                # submit → wait → download
 
 ## Scope
 
-First-iteration demo slice: submit a workflow, poll job status, download outputs.
-Not yet here (see the plan): file upload, the live-progress stream, idempotency, a
-durable job store, and the resilient WebSocket client for progress. This slice
-serves job status by plain polling.
+First-iteration slice: submit a workflow, poll job status, download outputs.
+Not yet here: file upload, the live-progress stream, idempotency, a durable job
+store, and the resilient WebSocket client for progress. This slice serves job
+status by plain polling.


### PR DESCRIPTION
Removes the pointer to an internal planning doc and internal service names from the README so the default branch is clean before this repository is made public.

No behavior change — README text only. The same scrub is already applied on the code PR branch (#1) and its comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)