### PR TITLE
ci: add CODEOWNERS and harden workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Default owners for everything in the repo. A pull request that touches any
+# file requires an approving review from at least one member of these teams
+# (enforced by the "Requirements to Merge to Main" ruleset).
+* @Comfy-Org/comfy-cloud-team @Comfy-Org/core-engine-team

--- a/.github/workflows/ci-audit-workflows.yml
+++ b/.github/workflows/ci-audit-workflows.yml
@@ -1,0 +1,34 @@
+name: CI - Audit Workflows
+
+on:
+  push:
+    branches:
+      - main
+  # No `branches` filter on pull_request so the audit runs on every PR
+  # regardless of base branch (matches the convention in Comfy-Org/cloud).
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run Zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          version: "v1.22.0"
+          advanced-security: false
+          online-audits: false
+          inputs: .github/workflows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,15 @@ jobs:
   lint:
     name: Lint & format (ruff)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
           cache: pip
@@ -38,12 +41,15 @@ jobs:
   typecheck:
     name: Type-check (mypy)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
           cache: pip
@@ -57,12 +63,15 @@ jobs:
   spec-drift:
     name: Spec-drift check (models match spec/openapi.yaml)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
           cache: pip
@@ -95,10 +104,12 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip


### PR DESCRIPTION
## What

- **`.github/CODEOWNERS`** — `@Comfy-Org/comfy-cloud-team` and `@Comfy-Org/core-engine-team` own the whole repo. This backs the code-owner-review requirement in the "Requirements to Merge to Main" ruleset.
- **CI hardening (`ci.yml`)**:
  - All actions pinned to full commit SHAs (`actions/checkout@v4.2.2`, `actions/setup-python@v5.6.0`).
  - `persist-credentials: false` on every checkout.
  - `timeout-minutes: 10` on all jobs (previously only the test matrix had a timeout).
  - Job display names unchanged, so the existing required status checks keep matching.
- **New `ci-audit-workflows.yml`** — zizmor workflow-security audit on every PR and push to main, matching the convention in other org repos.

## Verification

- `zizmor v1.22.0` (the exact version the new job runs) passes locally against `.github/workflows` with no findings.
- No behavior change to lint/typecheck/spec-drift/test jobs beyond pinning and timeouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)