### PR TITLE
Enforce Idempotency-Key: reject-on-duplicate (single-use, no replay)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,10 +240,9 @@ Known limitations:
   HMAC-signed stateless output ids, since the signing secret is regenerated per
   process. A client that persists an id across a proxy restart must expect a 404;
   a durable store is a follow-up.
-- **`Idempotency-Key` is accepted but not yet enforced.** The header documented
-  in the contract is not rejected (the SDK sends one on every submit), but there
-  is no dedup/replay yet — a retried request runs again. Stakes are lower than a
-  billed surface, but don't rely on it for exactly-once until the durable store
-  lands.
+- **`Idempotency-Key` dedup is in-memory.** A reused key is rejected
+  (`422 idempotency_key_reuse` — keys are single-use, no replay), but the claim
+  set lives in the process and is cleared on restart, so a key reused across a
+  proxy restart is not detected. A durable store is a follow-up.
 - **Uploads are not zero-copy.** Large uploads are read fully into memory / a
   temp file rather than true streaming.

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -136,10 +136,7 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
         '409':
-          description: '`hash_mismatch` or `idempotency_conflict`.'
-          headers:
-            Retry-After:
-              $ref: '#/components/headers/RetryAfter'
+          description: '`hash_mismatch`.'
           content:
             application/json:
               schema:
@@ -330,17 +327,19 @@ paths:
         rejected with `workflow_format_ui`.
 
 
-        `Idempotency-Key` follows Stripe semantics: a retry with the same
+        `Idempotency-Key` is single-use (reject-on-duplicate): the first use
 
-        key and body replays the recorded response (`Idempotency-Replayed:
+        of a key claims it; any reuse returns `422` `idempotency_key_reuse`.
 
-        true`, same job, no second execution); same key with a different
+        The claim is released only if the submission was definitively rejected
 
-        body is `422` `idempotency_key_reuse`; a concurrent retry while the
+        (no job created); on an ambiguous outcome (the upstream was
 
-        first is in flight is `409` with `Retry-After`. Keys expire after
+        unreachable) it is held so a retry cannot double-submit. Keys are held
 
-        24h.
+        in memory for the process lifetime — there is no replay and no
+
+        cross-restart persistence yet.
 
 
         Reserved for post-MVP and rejected if present today: `webhook_url`,
@@ -367,9 +366,6 @@ paths:
       responses:
         '201':
           description: Job created and queued.
-          headers:
-            Idempotency-Replayed:
-              $ref: '#/components/headers/IdempotencyReplayed'
           content:
             application/json:
               schema:
@@ -384,15 +380,6 @@ paths:
                 $ref: '#/components/schemas/ErrorEnvelope'
         '403':
           $ref: '#/components/responses/Forbidden'
-        '409':
-          description: '`idempotency_conflict` — concurrent retry in flight.'
-          headers:
-            Retry-After:
-              $ref: '#/components/headers/RetryAfter'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorEnvelope'
         '422':
           description: '`invalid_workflow` (with per-node details), `workflow_format_ui`,
             `missing_asset`, or `idempotency_key_reuse`.'
@@ -553,8 +540,9 @@ components:
       required: false
       schema:
         type: string
-      description: Client-generated UUID (recommended). Stripe semantics; keys expire after
-        24h.
+      description: 'Client-generated UUID (recommended). Single-use, reject-on-duplicate —
+        a reused key returns `422` `idempotency_key_reuse`. Held in memory for the process
+        lifetime; no replay, no cross-restart persistence yet.'
     JobId:
       name: id
       in: path
@@ -582,11 +570,6 @@ components:
       schema:
         type: integer
       description: Seconds to wait before retrying.
-    IdempotencyReplayed:
-      schema:
-        type: boolean
-      description: '`true` when this response was replayed from a previously recorded request
-        with the same Idempotency-Key.'
   responses:
     Unauthorized:
       description: '`unauthorized` — missing or invalid credentials.'
@@ -877,7 +860,7 @@ components:
 
         `missing_asset` (422), `hash_mismatch` (409), `blob_not_found`
 
-        (404), `idempotency_key_reuse` (422), `idempotency_conflict` (409),
+        (404), `idempotency_key_reuse` (422), `invalid_request` (400),
 
         `queue_full` (429 + Retry-After), `insufficient_credits` (402),
 

--- a/src/comfy_api_proxy/app.py
+++ b/src/comfy_api_proxy/app.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import collections
 import contextlib
 import hashlib
 import hmac
@@ -68,6 +69,15 @@ _DEFAULT_MAX_UPLOAD_BYTES = 100 * 1024 * 1024
 _MAX_CONCURRENT_STREAMS = 8
 
 _RETENTION = timedelta(hours=24)
+
+# Idempotency-Key bounds. A per-instance self-hosted proxy holds claimed keys
+# in memory, so cap both the length of any single key and the total number
+# retained — otherwise a caller could grow the set without bound (memory
+# exhaustion) by sending unique, arbitrarily long keys. Past the count cap the
+# oldest claim is evicted (FIFO); the window is generous enough to cover any
+# realistic retry horizon for a single-instance proxy.
+_MAX_IDEMPOTENCY_KEY_LEN = 255
+_MAX_IDEMPOTENCY_KEYS = 10_000
 
 
 def _error(status: int, code: str, message: str, **details: Any) -> web.Response:
@@ -157,10 +167,12 @@ class Proxy:
         # job_id -> {"workflow": ..., "created_at": datetime, "client_id": str}
         self._jobs: dict[str, dict[str, Any]] = {}
         # Claimed Idempotency-Key values (single-use, reject-on-duplicate — no
-        # replay, matching the v2 contract). In-memory and unbounded, which is
-        # fine for a per-instance self-hosted proxy: keys live for the process
-        # lifetime and a restart clears them, exactly like _jobs above.
-        self._idempotency_keys: set[str] = set()
+        # replay, matching the v2 contract). In-memory for a per-instance
+        # self-hosted proxy: keys live for the process lifetime and a restart
+        # clears them. Bounded in size (see _MAX_IDEMPOTENCY_KEYS) with FIFO
+        # eviction; an OrderedDict is used as an ordered set so the oldest
+        # claim can be popped when the cap is reached.
+        self._idempotency_keys: collections.OrderedDict[str, None] = collections.OrderedDict()
         self._session: ClientSession | None = None
         self._open_streams = 0
         # Per-process secret used to HMAC-sign stateless output asset ids
@@ -476,7 +488,16 @@ class Proxy:
         # unknown outcome (ComfyUI unreachable — it may already hold the prompt)
         # the key is HELD so a same-key retry can't double-submit.
         key = request.headers.get("Idempotency-Key")
-        if key:
+        if key is not None:
+            # A present-but-empty header is malformed input, not "no key"; and
+            # cap the length so a caller can't grow the in-memory set with an
+            # arbitrarily long key.
+            if not key or len(key) > _MAX_IDEMPOTENCY_KEY_LEN:
+                return _error(
+                    400,
+                    "invalid_request",
+                    f"Idempotency-Key must be 1-{_MAX_IDEMPOTENCY_KEY_LEN} characters.",
+                )
             if key in self._idempotency_keys:
                 return _error(
                     422,
@@ -484,7 +505,9 @@ class Proxy:
                     "This Idempotency-Key has already been used. Keys are single-use; "
                     "poll or list your jobs instead of resubmitting with the same key.",
                 )
-            self._idempotency_keys.add(key)
+            self._idempotency_keys[key] = None
+            if len(self._idempotency_keys) > _MAX_IDEMPOTENCY_KEYS:
+                self._idempotency_keys.popitem(last=False)  # evict oldest (FIFO)
 
         payload = {
             "prompt": resolved_workflow,
@@ -493,16 +516,23 @@ class Proxy:
         }
         try:
             async with self.session.post(self.comfyui + "/prompt", json=payload) as r:
-                data = await r.json() if r.content_type == "application/json" else {}
                 if r.status != 200:
+                    # A definite non-200 means ComfyUI created no job. Release
+                    # the key for a retry based on the status ALONE, before
+                    # reading the body — a failed body read must not turn a
+                    # definite rejection into a (wrongly) held key.
                     if key:
-                        self._idempotency_keys.discard(
-                            key
-                        )  # ComfyUI rejected it — no job; release for a retry
+                        self._idempotency_keys.pop(key, None)
+                    try:
+                        data = await r.json() if r.content_type == "application/json" else {}
+                    except (ClientError, asyncio.TimeoutError, ValueError):
+                        data = {}
                     node_errors = data.get("node_errors") or {}
                     msg = (data.get("error") or {}).get("message", "Workflow rejected.")
                     return _error(422, "invalid_workflow", msg, node_errors=node_errors)
         except (ClientError, asyncio.TimeoutError):
+            # Unknown outcome — ComfyUI may already hold the prompt. HOLD the
+            # key (do not release) so a same-key retry can't double-submit.
             return _error(503, "upstream_unreachable", "Could not reach ComfyUI to submit the job.")
         self._jobs[job_id] = {"workflow": workflow, "created_at": _now(), "client_id": job_id}
         base = _external_base(request)

--- a/src/comfy_api_proxy/app.py
+++ b/src/comfy_api_proxy/app.py
@@ -156,6 +156,11 @@ class Proxy:
         self.assets = AssetStore()
         # job_id -> {"workflow": ..., "created_at": datetime, "client_id": str}
         self._jobs: dict[str, dict[str, Any]] = {}
+        # Claimed Idempotency-Key values (single-use, reject-on-duplicate — no
+        # replay, matching the v2 contract). In-memory and unbounded, which is
+        # fine for a per-instance self-hosted proxy: keys live for the process
+        # lifetime and a restart clears them, exactly like _jobs above.
+        self._idempotency_keys: set[str] = set()
         self._session: ClientSession | None = None
         self._open_streams = 0
         # Per-process secret used to HMAC-sign stateless output asset ids
@@ -463,6 +468,24 @@ class Proxy:
         # different client_id) silently gets none. Using job_id itself as
         # the client_id gives each job's own SSE bridge (see job_events,
         # which connects with this same id) a 1:1 addressable target.
+        # Idempotency-Key: single-use, reject-on-duplicate (no replay), matching
+        # the v2 contract. Claim it synchronously (no await between the
+        # membership test and the add) so two concurrent submits with the same
+        # key can't both pass. The claim is released below only if the submit
+        # DEFINITELY created no job (ComfyUI rejected the workflow); on an
+        # unknown outcome (ComfyUI unreachable — it may already hold the prompt)
+        # the key is HELD so a same-key retry can't double-submit.
+        key = request.headers.get("Idempotency-Key")
+        if key:
+            if key in self._idempotency_keys:
+                return _error(
+                    422,
+                    "idempotency_key_reuse",
+                    "This Idempotency-Key has already been used. Keys are single-use; "
+                    "poll or list your jobs instead of resubmitting with the same key.",
+                )
+            self._idempotency_keys.add(key)
+
         payload = {
             "prompt": resolved_workflow,
             "prompt_id": job_id,
@@ -472,6 +495,10 @@ class Proxy:
             async with self.session.post(self.comfyui + "/prompt", json=payload) as r:
                 data = await r.json() if r.content_type == "application/json" else {}
                 if r.status != 200:
+                    if key:
+                        self._idempotency_keys.discard(
+                            key
+                        )  # ComfyUI rejected it — no job; release for a retry
                     node_errors = data.get("node_errors") or {}
                     msg = (data.get("error") or {}).get("message", "Workflow rejected.")
                     return _error(422, "invalid_workflow", msg, node_errors=node_errors)

--- a/src/comfy_api_proxy/schemas/_generated.py
+++ b/src/comfy_api_proxy/schemas/_generated.py
@@ -137,7 +137,7 @@ class ErrorEnvelope(BaseModel):
     Shared error envelope with machine-readable codes. Core codes (v1):
     `invalid_workflow` (422), `workflow_format_ui` (422),
     `missing_asset` (422), `hash_mismatch` (409), `blob_not_found`
-    (404), `idempotency_key_reuse` (422), `idempotency_conflict` (409),
+    (404), `idempotency_key_reuse` (422), `invalid_request` (400),
     `queue_full` (429 + Retry-After), `insufficient_credits` (402),
     `not_found` (404), `unauthorized` (401), `forbidden` (403).
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -613,10 +613,9 @@ def test_model_asset_ref_resolves_to_root_relative_filename(stack_with_models_di
 # 422 mapping: reserved top-level fields and a missing 'workflow' key.
 #
 # test_reserved_fields_rejected (above) only exercises 'webhook_url'; submit()
-# rejects 'inputs' the same way (it isn't accepted until the not-yet-built
-# Idempotency-Key / replay path exists), and a request with no 'workflow' key
-# at all is a distinct code path from both the reserved-field check and the
-# UI-format-graph check.
+# rejects 'inputs' the same way (a reserved field, not accepted in v1), and a
+# request with no 'workflow' key at all is a distinct code path from both the
+# reserved-field check and the UI-format-graph check.
 # ---------------------------------------------------------------------------
 def test_submit_reserved_inputs_field_rejected(stack):
     status, body, raw = stack.request(
@@ -630,6 +629,20 @@ def test_submit_missing_workflow_key_rejected(stack):
     status, body, raw = stack.request("POST", "/api/v2/jobs", {})
     assert status == 422, raw
     assert body["error"]["code"] == "invalid_workflow"
+
+
+def test_idempotency_key_reuse_rejected(stack):
+    # Single-use, reject-on-duplicate (no replay): the first submit with a key
+    # succeeds; a second submit reusing the same key is 422 idempotency_key_reuse;
+    # a different key is accepted.
+    wf = {"workflow": {"1": {"class_type": "Noop", "inputs": {}}}}
+    s1, _, r1 = stack.request("POST", "/api/v2/jobs", wf, headers={"Idempotency-Key": "key-abc"})
+    assert s1 == 201, r1
+    s2, b2, r2 = stack.request("POST", "/api/v2/jobs", wf, headers={"Idempotency-Key": "key-abc"})
+    assert s2 == 422, r2
+    assert b2["error"]["code"] == "idempotency_key_reuse"
+    s3, _, r3 = stack.request("POST", "/api/v2/jobs", wf, headers={"Idempotency-Key": "key-xyz"})
+    assert s3 == 201, r3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -645,6 +645,95 @@ def test_idempotency_key_reuse_rejected(stack):
     assert s3 == 201, r3
 
 
+def test_idempotency_key_released_on_rejection_allows_retry(stack):
+    # A submit that ComfyUI DEFINITELY rejects (no job created) must release
+    # the key so a corrected retry with the SAME key can go through. An empty
+    # graph makes the fake ComfyUI return 400 -> the proxy maps it to 422
+    # invalid_workflow and releases the key.
+    bad = {"workflow": {}}
+    s1, b1, r1 = stack.request("POST", "/api/v2/jobs", bad, headers={"Idempotency-Key": "rel-1"})
+    assert s1 == 422, r1
+    assert b1["error"]["code"] == "invalid_workflow"
+    good = {"workflow": {"1": {"class_type": "Noop", "inputs": {}}}}
+    s2, _, r2 = stack.request("POST", "/api/v2/jobs", good, headers={"Idempotency-Key": "rel-1"})
+    assert s2 == 201, r2  # key was released by the rejection, retry allowed
+
+
+def test_idempotency_key_not_consumed_by_earlier_validation(stack):
+    # Validation that runs BEFORE the key is claimed (UI-format detection here)
+    # must not consume the key: a corrected retry with the same key succeeds.
+    ui = {"workflow": {"nodes": [], "links": []}}
+    s1, b1, r1 = stack.request("POST", "/api/v2/jobs", ui, headers={"Idempotency-Key": "val-1"})
+    assert s1 == 422, r1
+    assert b1["error"]["code"] == "workflow_format_ui"
+    good = {"workflow": {"1": {"class_type": "Noop", "inputs": {}}}}
+    s2, _, r2 = stack.request("POST", "/api/v2/jobs", good, headers={"Idempotency-Key": "val-1"})
+    assert s2 == 201, r2
+
+
+def test_idempotency_key_empty_header_rejected(stack):
+    # A present-but-empty Idempotency-Key is malformed input (400), not "no key"
+    # (which would silently bypass enforcement).
+    wf = {"workflow": {"1": {"class_type": "Noop", "inputs": {}}}}
+    s, b, r = stack.request("POST", "/api/v2/jobs", wf, headers={"Idempotency-Key": ""})
+    assert s == 400, r
+    assert b["error"]["code"] == "invalid_request"
+    # An over-long key is likewise rejected before it can be stored.
+    s2, b2, r2 = stack.request("POST", "/api/v2/jobs", wf, headers={"Idempotency-Key": "x" * 256})
+    assert s2 == 400, r2
+    assert b2["error"]["code"] == "invalid_request"
+
+
+def test_idempotency_key_concurrent_same_key_one_wins(stack):
+    # Two genuinely concurrent submits with the same key: exactly one is
+    # accepted (201) and the other is rejected (422). This is the property the
+    # synchronous check-then-claim (no await between test and add) guarantees.
+    import concurrent.futures
+
+    wf = {"workflow": {"1": {"class_type": "Noop", "inputs": {"hang": True}}}}
+
+    def submit():
+        return stack.request("POST", "/api/v2/jobs", wf, headers={"Idempotency-Key": "conc-1"})[0]
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as ex:
+        statuses = sorted(f.result() for f in [ex.submit(submit), ex.submit(submit)])
+    assert statuses == [201, 422], statuses
+
+
+async def test_idempotency_key_held_when_upstream_unreachable():
+    # An ambiguous outcome (ComfyUI unreachable) HOLDS the key: ComfyUI may
+    # already hold the prompt, so a same-key retry must not double-submit. The
+    # first submit is 503; a retry with the same key is 422 idempotency_key_reuse.
+    from aiohttp.test_utils import make_mocked_request
+
+    from comfy_api_proxy.app import Proxy
+
+    def _submit_req(key):
+        req = make_mocked_request(
+            "POST",
+            "/api/v2/jobs",
+            headers={"Content-Type": "application/json", "Idempotency-Key": key},
+        )
+
+        async def _json():
+            return {"workflow": {"1": {"class_type": "Noop", "inputs": {}}}}
+
+        req.json = _json
+        return req
+
+    proxy = Proxy("http://127.0.0.1:1")  # port 1 -> connection refused
+    await proxy.on_startup(None)
+    try:
+        first = await proxy.submit(_submit_req("hold-1"))
+        assert first.status == 503
+        assert json.loads(first.body)["error"]["code"] == "upstream_unreachable"
+        second = await proxy.submit(_submit_req("hold-1"))
+        assert second.status == 422
+        assert json.loads(second.body)["error"]["code"] == "idempotency_key_reuse"
+    finally:
+        await proxy.on_cleanup(None)
+
+
 # ---------------------------------------------------------------------------
 # Cancel of an already-terminal job must be a harmless no-op: cancel_job()
 # calls ComfyUI's cancel unconditionally when the job is known to the proxy,


### PR DESCRIPTION
Follow-up to #5 (merged): the `Idempotency-Key` header was accepted but unenforced — a retried submit ran again. This wires up the reject-on-duplicate enforcement that landed on the PR branch after #5 was squash-merged, so it wasn't included.

`submit()` now claims the key before forwarding to ComfyUI and rejects any reuse with `422 idempotency_key_reuse`, matching the v2 contract. The claim is released if ComfyUI definitively rejects the workflow (no job created, so a retry can proceed) and held on an unknown outcome (ComfyUI unreachable — it may already hold the prompt) so a same-key retry can't double-submit. The claim set is in-memory (cleared on restart) — documented as a known limitation; a durable store is a follow-up.

Test: `test_idempotency_key_reuse_rejected`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)