### PR TITLE
fix: map an upstream 5xx/403 on output content to 502, not 404

### DIFF
--- a/src/comfy_api_proxy/app.py
+++ b/src/comfy_api_proxy/app.py
@@ -937,8 +937,16 @@ class Proxy:
         except Exception:
             return _error(500, "upstream_error", "Failed to reach ComfyUI for content.")
         if upstream.status not in (200, 206):
+            status = upstream.status
             upstream.release()
-            return _error(404, "not_found", "Output not available upstream.")
+            # A genuine 404 means the output isn't there; any other non-2xx
+            # (a ComfyUI-side 5xx, 403, ...) is an upstream failure, not a
+            # "never existed" — surface it as such instead of masking it as 404.
+            if status == 404:
+                return _error(404, "not_found", "Output not available upstream.")
+            return _error(
+                502, "upstream_error", "ComfyUI returned an unexpected status for the output."
+            )
         out = web.StreamResponse(status=upstream.status)
         out.content_type = upstream.content_type
         for h in ("Content-Length", "Content-Range", "Accept-Ranges"):

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -877,3 +877,42 @@ def test_sse_stream_cap_returns_429_and_frees_slot_when_job_finishes(stack):
         for resp in opened:
             with contextlib.suppress(Exception):
                 resp.close()
+
+
+async def test_asset_content_upstream_5xx_maps_to_502_but_404_stays_404():
+    # A genuine upstream 404 means the output isn't there (-> 404); any other
+    # non-2xx from ComfyUI is an upstream failure (-> 502 upstream_error), not
+    # a "never existed" 404.
+    from aiohttp.test_utils import make_mocked_request
+
+    from comfy_api_proxy.app import Proxy
+
+    class _Resp:
+        def __init__(self, status: int) -> None:
+            self.status = status
+            self.content_type = "image/png"
+            self.headers: dict[str, str] = {}
+
+        def release(self) -> None:
+            pass
+
+    class _Session:
+        def __init__(self, status: int) -> None:
+            self._status = status
+
+        async def get(self, url, params=None, headers=None):  # noqa: ANN001
+            return _Resp(self._status)
+
+    cases = [(500, 502, "upstream_error"), (403, 502, "upstream_error"), (404, 404, "not_found")]
+    for upstream_status, expected_status, expected_code in cases:
+        proxy = Proxy("http://comfy")
+        proxy._session = _Session(upstream_status)  # type: ignore[assignment]
+        rec = proxy.assets.register_comfy_output(
+            filename="out.png", subfolder="", type_="output", content_type="image/png"
+        )
+        req = make_mocked_request(
+            "GET", f"/api/v2/assets/{rec.id}/content", match_info={"id": rec.id}
+        )
+        resp = await proxy.get_asset_content(req)
+        assert resp.status == expected_status, (upstream_status, resp.status)
+        assert json.loads(resp.body)["error"]["code"] == expected_code


### PR DESCRIPTION
`get_asset_content` mapped **any** non-2xx response from ComfyUI's `/view` to a client-facing `404 not_found`, collapsing "this output never existed" with "ComfyUI is broken right now." The sibling upload/connection paths already use `502`/`500 upstream_error`.

This maps a genuine upstream `404` to `404`, but any other non-2xx (a ComfyUI-side `5xx`, `403`, …) to `502 upstream_error`. Adds a direct test covering `500`/`403` → `502` and `404` → `404`.

Full suite: **121 passed**; ruff + mypy clean.

Note: this fix was authored during the earlier review round but got stranded — PR #8 squash-merged before the follow-up commit landed, so it never reached `main`. Re-landing it against current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)