### PR TITLE
feat: pip-installable package with background start/stop + PyPI publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,157 @@
+# Publishes `comfy-api-proxy` to PyPI.
+#
+# Tag-driven versioning: the release tag (vX.Y.Z) is the single source of truth
+# for the published version. It is injected into pyproject.toml at build time,
+# so the committed version there is just a placeholder — to release a version,
+# create a GitHub Release with the tag you want; no version-bump commit needed.
+#
+# Trigger: a GitHub Release being published (tag vX.Y.Z). That's the only
+# path that reaches the `publish` job below. `workflow_dispatch` is a dry
+# run only — it exercises `build` (compile + `twine check`) but never
+# reaches `publish`, so it's safe to run against any branch to sanity-check
+# the pipeline before cutting a real release.
+#
+# Auth: PyPI Trusted Publishing (OIDC) — no PYPI_TOKEN / API token secret is
+# stored in this repo. A trusted publisher configured on pypi.org for this
+# repo + this workflow + the `pypi` environment is the one-time setup this
+# depends on.
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to build for a dry run (build + twine check only — this input never reaches the publish job)'
+        required: false
+        type: string
+        default: ''
+      publish_to_testpypi:
+        description: 'Also upload the built dist to TestPyPI (requires the optional "testpypi" environment + Trusted Publisher)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-${{ github.workflow }}-${{ github.event.release.tag_name || github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  # Runs for every trigger. Builds the exact sdist/wheel that `publish` will
+  # upload and validates it with twine. This IS the workflow_dispatch dry
+  # run: trigger this workflow manually via the Actions tab and you get this
+  # job (and nothing else, since `publish` requires a `release` event).
+  build:
+    name: Build and check distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.12'
+
+      - name: Install build tooling
+        run: pip install build twine
+
+      # Tag-driven versioning: the release tag (vX.Y.Z) is the source of truth.
+      # Inject it into pyproject.toml before building so the published artifact
+      # carries the tag's version. (On a workflow_dispatch dry run there is no
+      # release tag; the committed placeholder version is built as-is.)
+      - name: Set version from release tag
+        if: github.event_name == 'release'
+        shell: bash
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          # Full SemVer 2.0: X.Y.Z, with an optional -prerelease and an
+          # optional +build-metadata segment (both may be present together).
+          if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+            echo "::error::Release tag '${TAG}' is not a valid version (expected vX.Y.Z)."
+            exit 1
+          fi
+          python3 - "$VERSION" <<'PY'
+          import re, sys
+          version = sys.argv[1]
+          p = "pyproject.toml"
+          s = open(p, encoding="utf-8").read()
+          s2, n = re.subn(r'(?m)^version = "[^"]+"$', f'version = "{version}"', s, count=1)
+          if n != 1:
+              raise SystemExit('could not find a top-level version = "..." line in pyproject.toml')
+          open(p, "w", encoding="utf-8").write(s2)
+          print(f"Set pyproject.toml version = {version}")
+          PY
+
+      - name: Build wheel and sdist
+        run: python -m build
+
+      - name: Verify distribution metadata (twine check)
+        run: twine check dist/*
+
+      - name: Upload built distribution
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pypi-dist
+          path: dist/
+          retention-days: 7
+
+  publish:
+    name: Publish to PyPI
+    needs: [build]
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    # Manual approval gate: the `pypi` environment (Settings -> Environments)
+    # has required reviewers, so every publish needs a human click even though
+    # the trigger (release published) is automatic.
+    environment: pypi
+    permissions:
+      id-token: write # OIDC for PyPI Trusted Publishing — no API token secret
+      contents: read
+    steps:
+      - name: Download built distribution
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pypi-dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        with:
+          packages-dir: dist/
+          skip-existing: true # idempotent re-runs: no-op instead of erroring if this version is already up
+
+  # Nice-to-have: exercise the full OIDC publish path against TestPyPI
+  # without touching real PyPI. Opt-in via workflow_dispatch input; needs
+  # its own Trusted Publisher + "testpypi" environment.
+  publish-testpypi:
+    name: Publish to TestPyPI (dry run)
+    needs: [build]
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_to_testpypi == 'true'
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Download built distribution
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pypi-dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        with:
+          packages-dir: dist/
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,6 +53,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/README.md
+++ b/README.md
@@ -14,12 +14,10 @@ pointed.
 ## Requirements & install
 
 - Python **3.10+** (CI runs 3.10, 3.11, and 3.12 on every pull request).
-- Not yet published to PyPI — install from a checkout:
+- Install from PyPI:
 
   ```bash
-  git clone https://github.com/Comfy-Org/comfy-api-proxy
-  cd comfy-api-proxy
-  pip install -e .
+  pip install comfy-api-proxy
   ```
 
 ## Quickstart
@@ -30,12 +28,17 @@ Point the proxy at an already-running ComfyUI and it serves `/api/v2/*` on
 its own port:
 
 ```bash
-pip install -e .
-comfy-api-proxy --comfyui http://127.0.0.1:8188 --port 8189
+# Start in the background (defaults: ComfyUI at 127.0.0.1:8188, serve on :8189):
+comfy-api-proxy start
+comfy-api-proxy status
+comfy-api-proxy stop
 
-# co-located with ComfyUI, to also enable model-directory uploads:
-comfy-api-proxy --comfyui http://127.0.0.1:8188 --port 8189 \
+# Point it elsewhere / co-locate with ComfyUI to enable model-directory uploads:
+comfy-api-proxy start --comfyui http://127.0.0.1:8188 --port 8189 \
   --comfyui-base-dir /path/to/ComfyUI
+
+# Or run in the foreground (Ctrl+C to stop):
+comfy-api-proxy run
 ```
 
 ### No-GPU demo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [project]
 name = "comfy-api-proxy"
-version = "0.0.1"
+version = "0.1.0"
 description = "Local proxy exposing the Comfy API v2 in front of a self-hosted ComfyUI instance."
+readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.9",
@@ -23,6 +24,11 @@ dev = [
 
 [project.scripts]
 comfy-api-proxy = "comfy_api_proxy.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/Comfy-Org/comfy-api-proxy"
+Repository = "https://github.com/Comfy-Org/comfy-api-proxy"
+Issues = "https://github.com/Comfy-Org/comfy-api-proxy/issues"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/comfy_api_proxy/__init__.py
+++ b/src/comfy_api_proxy/__init__.py
@@ -5,4 +5,13 @@ download outputs. No file upload, no live-progress stream, no idempotency yet â€
 those follow in later iterations.
 """
 
-__version__ = "0.0.1"
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
+try:
+    # Single source of truth: the installed package metadata (which the
+    # tag-driven release injects into pyproject.toml at build time). Avoids a
+    # hardcoded value drifting from the published version.
+    __version__ = _pkg_version("comfy-api-proxy")
+except PackageNotFoundError:  # running from a source tree without an install
+    __version__ = "0.0.0+unknown"

--- a/src/comfy_api_proxy/cli.py
+++ b/src/comfy_api_proxy/cli.py
@@ -1,4 +1,14 @@
-"""Command-line entry point: ``comfy-api-proxy --comfyui URL --port N``.
+"""Command-line entry point.
+
+Usage:
+
+  * ``comfy-api-proxy`` / ``comfy-api-proxy run`` — run in the foreground
+    (Ctrl+C to stop). A bare invocation with flags is treated as ``run`` for
+    backward compatibility.
+  * ``comfy-api-proxy start`` — start in the background (detached); prints the
+    URL and returns.
+  * ``comfy-api-proxy stop`` — stop the background proxy.
+  * ``comfy-api-proxy status`` — report whether the background proxy is running.
 
 Security posture (the defaults are the safety net):
 
@@ -19,9 +29,12 @@ import sys
 
 from aiohttp import web
 
+from . import service
 from .app import _DEFAULT_MAX_UPLOAD_BYTES, make_app
 from .auth import make_bearer_auth_middleware
 from .middleware import origin_only_middleware
+
+_COMMANDS = {"run", "start", "stop", "status"}
 
 
 def _is_loopback_host(host: str) -> bool:
@@ -37,8 +50,7 @@ def _is_loopback_host(host: str) -> bool:
         return host == "localhost"
 
 
-def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(prog="comfy-api-proxy")
+def _add_server_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--comfyui",
         default="http://127.0.0.1:8188",
@@ -79,20 +91,25 @@ def main(argv: list[str] | None = None) -> int:
         help="Permit binding a non-loopback --host without a --token. Unsafe: "
         "exposes an unauthenticated proxy to the network.",
     )
-    args = parser.parse_args(argv)
 
+
+def _bind_refused(args: argparse.Namespace) -> bool:
     if not _is_loopback_host(args.host) and not args.token and not args.allow_insecure_bind:
         print(
             f"refusing to bind non-loopback host {args.host!r} without --token "
             "(pass --allow-insecure-bind to override).",
             file=sys.stderr,
         )
-        return 2
+        return True
+    return False
 
+
+def _run_foreground(args: argparse.Namespace) -> int:
+    if _bind_refused(args):
+        return 2
     middlewares: list = [origin_only_middleware]
     if args.token:
         middlewares.append(make_bearer_auth_middleware(args.token))
-
     app = make_app(
         args.comfyui,
         comfyui_base_dir=args.comfyui_base_dir,
@@ -101,6 +118,58 @@ def main(argv: list[str] | None = None) -> int:
     )
     web.run_app(app, host=args.host, port=args.port)
     return 0
+
+
+def _server_argv(args: argparse.Namespace) -> list[str]:
+    """Reconstruct the run flags to hand to a detached child process."""
+    argv = [
+        "--comfyui",
+        args.comfyui,
+        "--host",
+        args.host,
+        "--port",
+        str(args.port),
+        "--max-upload-mb",
+        str(args.max_upload_mb),
+    ]
+    if args.token:
+        argv += ["--token", args.token]
+    if args.comfyui_base_dir:
+        argv += ["--comfyui-base-dir", args.comfyui_base_dir]
+    if args.allow_insecure_bind:
+        argv += ["--allow-insecure-bind"]
+    return argv
+
+
+def main(argv: list[str] | None = None) -> int:
+    raw = list(sys.argv[1:] if argv is None else argv)
+    # Backward compatibility: a bare invocation (no subcommand, or leading flags)
+    # runs in the foreground, same as the original single-command CLI.
+    if not raw or (raw[0] not in _COMMANDS and raw[0] not in ("-h", "--help")):
+        raw = ["run", *raw]
+
+    parser = argparse.ArgumentParser(prog="comfy-api-proxy")
+    sub = parser.add_subparsers(dest="command", required=True)
+    run_p = sub.add_parser("run", help="Run in the foreground (Ctrl+C to stop).")
+    _add_server_args(run_p)
+    start_p = sub.add_parser("start", help="Start the proxy in the background.")
+    _add_server_args(start_p)
+    sub.add_parser("stop", help="Stop the background proxy.")
+    sub.add_parser("status", help="Show whether the background proxy is running.")
+
+    args = parser.parse_args(raw)
+
+    if args.command == "run":
+        return _run_foreground(args)
+    if args.command == "start":
+        if _bind_refused(args):
+            return 2
+        return service.start(_server_argv(args), args.host, args.port)
+    if args.command == "stop":
+        return service.stop()
+    if args.command == "status":
+        return service.status()
+    return 2  # unreachable (subparser is required)
 
 
 if __name__ == "__main__":

--- a/src/comfy_api_proxy/service.py
+++ b/src/comfy_api_proxy/service.py
@@ -5,6 +5,13 @@ records its PID and address in a single JSON file under a per-user state
 directory; `stop`/`status` read that file. There's no daemon manager here — the
 child is just the ordinary foreground `run` server, detached from the terminal.
 
+Identity: the state carries a PID, but a PID alone can be recycled by an
+unrelated process. `stop`/`status` therefore also confirm the process's command
+line looks like this proxy before acting on it (best-effort; falls back to a
+plain liveness check where the command line can't be read). And `start` refuses
+to launch onto an already-occupied port, so a bound port reported by another
+process is never mistaken for a successful start.
+
 The state directory can be overridden with `COMFY_API_PROXY_STATE_DIR` (used by
 the tests so they never touch the real user directory).
 """
@@ -20,6 +27,8 @@ import sys
 import time
 from pathlib import Path
 from typing import Any
+
+_MARKER = "comfy_api_proxy"  # substring expected in our child's command line
 
 
 def _state_dir() -> Path:
@@ -47,9 +56,22 @@ def read_state() -> dict[str, Any] | None:
     if not path.exists():
         return None
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        data = json.loads(path.read_text(encoding="utf-8"))
     except (ValueError, OSError):
         return None
+    # A corrupt or unexpected shape (e.g. `[]` or `{"pid": "abc"}`) must not
+    # crash callers — treat anything that isn't a well-formed record as "no
+    # state".
+    if not isinstance(data, dict) or _state_pid(data) <= 0:
+        return None
+    return data
+
+
+def _state_pid(state: dict[str, Any]) -> int:
+    try:
+        return int(state.get("pid", -1))
+    except (TypeError, ValueError):
+        return -1
 
 
 def _clear_state() -> None:
@@ -83,6 +105,126 @@ def _pid_alive(pid: int) -> bool:
     return True
 
 
+def _pid_cmdline(pid: int) -> str | None:
+    """Best-effort command line of a PID, or None if it can't be read here."""
+    try:
+        if os.name == "nt":
+            out = subprocess.run(
+                ["wmic", "process", "where", f"ProcessId={pid}", "get", "CommandLine"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        else:
+            out = subprocess.run(
+                ["ps", "-p", str(pid), "-o", "args="],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return out.stdout.strip() or None
+
+
+def _pid_is_ours(pid: int) -> bool:
+    """Is `pid` alive AND (best-effort) actually this proxy — not a recycled PID?
+
+    Falls back to a plain liveness check when the command line can't be
+    inspected, so behavior is never worse than tracking the PID alone.
+    """
+    if not _pid_alive(pid):
+        return False
+    cmdline = _pid_cmdline(pid)
+    if cmdline is None:
+        return True  # can't tell; assume it's ours rather than refuse to manage it
+    return _MARKER in cmdline
+
+
+def _connect_host(host: str) -> str:
+    # A bind address of "" or 0.0.0.0 isn't connectable; probe IPv4 loopback.
+    # A bind of :: (all IPv6) is probed via the IPv6 loopback.
+    if host in ("", "0.0.0.0"):
+        return "127.0.0.1"
+    if host == "::":
+        return "::1"
+    return host
+
+
+def _url(host: str, port: int) -> str:
+    target = _connect_host(host)
+    if ":" in target:  # IPv6 literal must be bracketed in a URL
+        return f"http://[{target}]:{port}"
+    return f"http://{target}:{port}"
+
+
+def _port_open(host: str, port: int, timeout: float = 0.5) -> bool:
+    try:
+        with socket.create_connection((_connect_host(host), port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def _wait_port(host: str, port: int, proc: subprocess.Popen[bytes], timeout: float = 15.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            return False  # the child exited before binding
+        if _port_open(host, port, timeout=1):
+            return True
+        time.sleep(0.2)
+    return False
+
+
+def start(run_argv: list[str], host: str, port: int) -> int:
+    """Launch the server detached; record its PID/address; wait for it to bind."""
+    existing = read_state()
+    if existing and _pid_is_ours(_state_pid(existing)):
+        print(
+            f"comfy-api-proxy is already running at {existing.get('url')} "
+            f"(pid {existing.get('pid')}).",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Refuse to start onto an occupied port: otherwise a port already held by
+    # another process would make the readiness check below pass while our child
+    # fails to bind and exits.
+    if _port_open(host, port):
+        print(
+            f"comfy-api-proxy cannot start: {_url(host, port)} is already in use. "
+            "Stop the other process or choose a different --port.",
+            file=sys.stderr,
+        )
+        return 1
+
+    cmd = [sys.executable, "-m", "comfy_api_proxy.cli", "run", *run_argv]
+    popen_kwargs: dict[str, Any] = {"stdin": subprocess.DEVNULL}
+    if os.name == "nt":
+        # DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
+        popen_kwargs["creationflags"] = 0x00000008 | 0x00000200
+    else:
+        popen_kwargs["start_new_session"] = True
+
+    log_path = _log_file()
+    with open(log_path, "ab") as log:
+        proc = subprocess.Popen(cmd, stdout=log, stderr=log, **popen_kwargs)
+
+    if not _wait_port(host, port, proc):
+        _terminate(proc.pid)
+        print(f"comfy-api-proxy failed to start; see {log_path}", file=sys.stderr)
+        return 1
+
+    url = _url(host, port)
+    _state_file().write_text(
+        json.dumps({"pid": proc.pid, "host": host, "port": port, "url": url}),
+        encoding="utf-8",
+    )
+    print(f"comfy-api-proxy started at {url} (pid {proc.pid}). Stop it with: comfy-api-proxy stop")
+    return 0
+
+
 def _terminate(pid: int) -> None:
     if os.name == "nt":
         subprocess.run(["taskkill", "/PID", str(pid), "/T", "/F"], capture_output=True, timeout=10)
@@ -101,77 +243,24 @@ def _terminate(pid: int) -> None:
         pass
 
 
-def _connect_host(host: str) -> str:
-    # A bind address of "", 0.0.0.0 or :: isn't connectable; probe loopback.
-    return "127.0.0.1" if host in ("", "0.0.0.0", "::") else host
-
-
-def _wait_port(host: str, port: int, proc: subprocess.Popen[bytes], timeout: float = 15.0) -> bool:
-    deadline = time.monotonic() + timeout
-    target = _connect_host(host)
-    while time.monotonic() < deadline:
-        if proc.poll() is not None:
-            return False  # the child exited before binding
-        try:
-            with socket.create_connection((target, port), timeout=1):
-                return True
-        except OSError:
-            time.sleep(0.2)
-    return False
-
-
-def start(run_argv: list[str], host: str, port: int) -> int:
-    """Launch the server detached; record its PID/address; wait for it to bind."""
-    existing = read_state()
-    if existing and _pid_alive(int(existing.get("pid", -1))):
-        print(
-            f"comfy-api-proxy is already running at {existing.get('url')} "
-            f"(pid {existing.get('pid')}).",
-            file=sys.stderr,
-        )
-        return 1
-
-    cmd = [sys.executable, "-m", "comfy_api_proxy.cli", "run", *run_argv]
-    popen_kwargs: dict[str, Any] = {"stdin": subprocess.DEVNULL}
-    if os.name == "nt":
-        # DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
-        popen_kwargs["creationflags"] = 0x00000008 | 0x00000200
-    else:
-        popen_kwargs["start_new_session"] = True
-
-    log_path = _log_file()
-    with open(log_path, "ab") as log:
-        proc = subprocess.Popen(cmd, stdout=log, stderr=log, **popen_kwargs)
-
-    url = f"http://{_connect_host(host)}:{port}"
-    if not _wait_port(host, port, proc):
-        _terminate(proc.pid)
-        print(f"comfy-api-proxy failed to start; see {log_path}", file=sys.stderr)
-        return 1
-
-    _state_file().write_text(
-        json.dumps({"pid": proc.pid, "host": host, "port": port, "url": url}),
-        encoding="utf-8",
-    )
-    print(f"comfy-api-proxy started at {url} (pid {proc.pid}). Stop it with: comfy-api-proxy stop")
-    return 0
-
-
 def stop() -> int:
     state = read_state()
-    if not state or not _pid_alive(int(state.get("pid", -1))):
+    pid = _state_pid(state) if state else -1
+    # Only terminate a process we can still identify as ours — never a PID that
+    # has since been recycled by something unrelated.
+    if not state or not _pid_is_ours(pid):
         _clear_state()
         print("comfy-api-proxy is not running.")
         return 0
-    _terminate(int(state["pid"]))
+    _terminate(pid)
     _clear_state()
-    print(f"comfy-api-proxy stopped (pid {state['pid']}).")
+    print(f"comfy-api-proxy stopped (pid {pid}).")
     return 0
 
 
 def status() -> int:
     state = read_state()
-    if state and _pid_alive(int(state.get("pid", -1))):
+    if state and _pid_is_ours(_state_pid(state)):
         print(f"comfy-api-proxy is running at {state.get('url')} (pid {state.get('pid')}).")
         return 0
     print("comfy-api-proxy is not running.")

--- a/src/comfy_api_proxy/service.py
+++ b/src/comfy_api_proxy/service.py
@@ -1,0 +1,178 @@
+"""Background start/stop for the proxy — a tiny, dependency-free supervisor.
+
+`comfy-api-proxy start` launches the server as a detached child process and
+records its PID and address in a single JSON file under a per-user state
+directory; `stop`/`status` read that file. There's no daemon manager here — the
+child is just the ordinary foreground `run` server, detached from the terminal.
+
+The state directory can be overridden with `COMFY_API_PROXY_STATE_DIR` (used by
+the tests so they never touch the real user directory).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+def _state_dir() -> Path:
+    override = os.environ.get("COMFY_API_PROXY_STATE_DIR")
+    if override:
+        directory = Path(override)
+    else:
+        base = os.environ.get("XDG_STATE_HOME")
+        root = Path(base) if base else Path.home() / ".local" / "state"
+        directory = root / "comfy-api-proxy"
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def _state_file() -> Path:
+    return _state_dir() / "proxy.json"
+
+
+def _log_file() -> Path:
+    return _state_dir() / "proxy.log"
+
+
+def read_state() -> dict[str, Any] | None:
+    path = _state_file()
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (ValueError, OSError):
+        return None
+
+
+def _clear_state() -> None:
+    _state_file().unlink(missing_ok=True)
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    if os.name == "nt":
+        # On Windows os.kill(pid, 0) would call TerminateProcess (killing it),
+        # so probe with tasklist instead.
+        try:
+            out = subprocess.run(
+                ["tasklist", "/FI", f"PID eq {pid}", "/NH"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            return str(pid) in out.stdout
+        except (OSError, subprocess.SubprocessError):
+            return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists but owned by another user
+    except OSError:
+        return False
+    return True
+
+
+def _terminate(pid: int) -> None:
+    if os.name == "nt":
+        subprocess.run(["taskkill", "/PID", str(pid), "/T", "/F"], capture_output=True, timeout=10)
+        return
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    for _ in range(50):  # up to ~5s for a graceful stop
+        if not _pid_alive(pid):
+            return
+        time.sleep(0.1)
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+
+
+def _connect_host(host: str) -> str:
+    # A bind address of "", 0.0.0.0 or :: isn't connectable; probe loopback.
+    return "127.0.0.1" if host in ("", "0.0.0.0", "::") else host
+
+
+def _wait_port(host: str, port: int, proc: subprocess.Popen[bytes], timeout: float = 15.0) -> bool:
+    deadline = time.monotonic() + timeout
+    target = _connect_host(host)
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            return False  # the child exited before binding
+        try:
+            with socket.create_connection((target, port), timeout=1):
+                return True
+        except OSError:
+            time.sleep(0.2)
+    return False
+
+
+def start(run_argv: list[str], host: str, port: int) -> int:
+    """Launch the server detached; record its PID/address; wait for it to bind."""
+    existing = read_state()
+    if existing and _pid_alive(int(existing.get("pid", -1))):
+        print(
+            f"comfy-api-proxy is already running at {existing.get('url')} "
+            f"(pid {existing.get('pid')}).",
+            file=sys.stderr,
+        )
+        return 1
+
+    cmd = [sys.executable, "-m", "comfy_api_proxy.cli", "run", *run_argv]
+    popen_kwargs: dict[str, Any] = {"stdin": subprocess.DEVNULL}
+    if os.name == "nt":
+        # DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
+        popen_kwargs["creationflags"] = 0x00000008 | 0x00000200
+    else:
+        popen_kwargs["start_new_session"] = True
+
+    log_path = _log_file()
+    with open(log_path, "ab") as log:
+        proc = subprocess.Popen(cmd, stdout=log, stderr=log, **popen_kwargs)
+
+    url = f"http://{_connect_host(host)}:{port}"
+    if not _wait_port(host, port, proc):
+        _terminate(proc.pid)
+        print(f"comfy-api-proxy failed to start; see {log_path}", file=sys.stderr)
+        return 1
+
+    _state_file().write_text(
+        json.dumps({"pid": proc.pid, "host": host, "port": port, "url": url}),
+        encoding="utf-8",
+    )
+    print(f"comfy-api-proxy started at {url} (pid {proc.pid}). Stop it with: comfy-api-proxy stop")
+    return 0
+
+
+def stop() -> int:
+    state = read_state()
+    if not state or not _pid_alive(int(state.get("pid", -1))):
+        _clear_state()
+        print("comfy-api-proxy is not running.")
+        return 0
+    _terminate(int(state["pid"]))
+    _clear_state()
+    print(f"comfy-api-proxy stopped (pid {state['pid']}).")
+    return 0
+
+
+def status() -> int:
+    state = read_state()
+    if state and _pid_alive(int(state.get("pid", -1))):
+        print(f"comfy-api-proxy is running at {state.get('url')} (pid {state.get('pid')}).")
+        return 0
+    print("comfy-api-proxy is not running.")
+    return 1

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,79 @@
+"""start / status / stop lifecycle for the background service.
+
+Drives the real CLI as a subprocess (with an isolated state dir) so the
+detached-child spawn, PID tracking, and teardown are all exercised end to end.
+ComfyUI doesn't need to be reachable — the proxy binds its own port regardless.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import time
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _cli(args: list[str], env: dict[str, str], timeout: float = 30.0):
+    return subprocess.run(
+        [sys.executable, "-m", "comfy_api_proxy.cli", *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=timeout,
+    )
+
+
+def _port_open(port: int) -> bool:
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+            return True
+    except OSError:
+        return False
+
+
+def test_start_status_stop_cycle(tmp_path):
+    port = _free_port()
+    env = {**os.environ, "COMFY_API_PROXY_STATE_DIR": str(tmp_path)}
+    run = ["start", "--port", str(port), "--comfyui", "http://127.0.0.1:1"]
+    try:
+        # Nothing running yet.
+        assert _cli(["status"], env).returncode == 1
+
+        started = _cli(run, env)
+        assert started.returncode == 0, started.stderr
+        assert "started" in started.stdout
+        assert _port_open(port)
+
+        running = _cli(["status"], env)
+        assert running.returncode == 0
+        assert "running" in running.stdout
+
+        # A second start is refused rather than double-binding.
+        again = _cli(run, env)
+        assert again.returncode == 1
+        assert "already running" in again.stderr
+    finally:
+        stopped = _cli(["stop"], env)
+        assert "stopped" in stopped.stdout or "not running" in stopped.stdout
+
+    # Port released and status reflects stopped.
+    for _ in range(50):
+        if not _port_open(port):
+            break
+        time.sleep(0.1)
+    assert not _port_open(port)
+    assert _cli(["status"], env).returncode == 1
+
+
+def test_stop_when_not_running_is_a_clean_no_op(tmp_path):
+    env = {**os.environ, "COMFY_API_PROXY_STATE_DIR": str(tmp_path)}
+    result = _cli(["stop"], env)
+    assert result.returncode == 0
+    assert "not running" in result.stdout

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -61,6 +61,7 @@ def test_start_status_stop_cycle(tmp_path):
         assert "already running" in again.stderr
     finally:
         stopped = _cli(["stop"], env)
+        assert stopped.returncode == 0, stopped.stderr
         assert "stopped" in stopped.stdout or "not running" in stopped.stdout
 
     # Port released and status reflects stopped.
@@ -77,3 +78,18 @@ def test_stop_when_not_running_is_a_clean_no_op(tmp_path):
     result = _cli(["stop"], env)
     assert result.returncode == 0
     assert "not running" in result.stdout
+
+
+def test_corrupt_state_file_is_ignored_not_a_crash(tmp_path):
+    # A malformed state file (bad JSON, wrong shape, non-int pid) must degrade
+    # to "not running" rather than tracebacking in status/stop.
+    env = {**os.environ, "COMFY_API_PROXY_STATE_DIR": str(tmp_path)}
+    state = tmp_path / "proxy.json"
+    for bad in ("not json at all", "[]", '{"pid": "abc"}', '{"nope": 1}'):
+        state.write_text(bad, encoding="utf-8")
+        st = _cli(["status"], env)
+        assert st.returncode == 1, (bad, st.stderr)
+        assert "not running" in st.stdout
+        state.write_text(bad, encoding="utf-8")
+        stop = _cli(["stop"], env)
+        assert stop.returncode == 0, (bad, stop.stderr)


### PR DESCRIPTION
Makes `comfy-api-proxy` an easily-installable package like the SDKs, and adds simple start/stop so users don't have to hold a terminal open.

## Install
```bash
pip install comfy-api-proxy
```
The console entry point already existed, so this just adds the publish pipeline + packaging metadata.

## Easy start / stop
New background service commands (a bare invocation / `run` stays foreground for backward compat):
```bash
comfy-api-proxy start      # detached; prints the URL and returns
comfy-api-proxy status     # running? where?
comfy-api-proxy stop
```
- Tracks the PID + address in one JSON state file under a per-user state dir (overridable via `COMFY_API_PROXY_STATE_DIR`).
- Cross-platform (POSIX `SIGTERM`/`SIGKILL`, Windows `taskkill`), no new dependencies.
- `start` waits for the port to bind and refuses to double-start.

## Publish pipeline
- `publish.yml` — tag-driven, **PyPI Trusted Publishing (OIDC)**, no stored token (mirrors the Python SDK). Cut a `vX.Y.Z` GitHub Release → CI builds and publishes, gated on the `pypi` environment.
- Version set to `0.1.0` to match the SDKs.
- Package metadata: `readme` + project URLs so the PyPI page renders.

## Tests / checks
- New `tests/test_service.py` covers the start → status → stop lifecycle (and stop-when-not-running).
- Full suite **123 passed**; ruff + mypy clean; `python -m build` + `twine check` pass; actionlint clean.

## One-time maintainer setup before the first release
- Configure a PyPI Trusted Publisher (pending publisher) for `comfy-api-proxy` → repo `Comfy-Org/comfy-api-proxy`, workflow `publish.yml`, environment `pypi`.
- Create a `pypi` GitHub Environment with required reviewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)