### PR TITLE
docs: fix Quickstart to match the actual CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,20 +25,18 @@ pointed.
 ### Against a real ComfyUI
 
 Point the proxy at an already-running ComfyUI and it serves `/api/v2/*` on
-its own port:
+its own port. It runs in the foreground until you stop it with Ctrl+C:
 
 ```bash
-# Start in the background (defaults: ComfyUI at 127.0.0.1:8188, serve on :8189):
-comfy-api-proxy start
-comfy-api-proxy status
-comfy-api-proxy stop
+# Defaults: proxy the ComfyUI at 127.0.0.1:8188, serve the v2 API on :8189.
+comfy-api-proxy
 
 # Point it elsewhere / co-locate with ComfyUI to enable model-directory uploads:
-comfy-api-proxy start --comfyui http://127.0.0.1:8188 --port 8189 \
+comfy-api-proxy --comfyui http://127.0.0.1:8188 --port 8189 \
   --comfyui-base-dir /path/to/ComfyUI
 
-# Or run in the foreground (Ctrl+C to stop):
-comfy-api-proxy run
+# Background it with your shell (& ) if you want your prompt back:
+comfy-api-proxy &
 ```
 
 ### No-GPU demo
@@ -200,7 +198,7 @@ comfy-api-proxy --comfyui http://127.0.0.1:8188 --port 8189 [options]
 
 Any real integration — and `demo/run_demo.py` — uses the same client SDKs
 Comfy Cloud users use, just pointed at this proxy's `--host:--port` instead
-of `api.comfy.org` / `cloud.comfy.org`:
+of `api.comfy.org`:
 
 - [ComfyPythonSDK](https://github.com/Comfy-Org/ComfyPythonSDK)
 - [ComfyTypeScriptSDK](https://github.com/Comfy-Org/ComfyTypeScriptSDK)


### PR DESCRIPTION
## What

Fixes the Quickstart, whose commands do not exist in the CLI.

## The bug

The README told users to run `comfy-api-proxy start` / `status` / `stop` / `run`. The CLI has **no subcommands** — it is a single foreground command (`comfy-api-proxy [flags]` → `web.run_app`). Following the Quickstart fails immediately:

```
comfy-api-proxy: error: unrecognized arguments: start
```

## Fix

- Rewrote the "Against a real ComfyUI" Quickstart to the real flat invocation (foreground; `&` to background), matching the already-correct CLI reference table and the demo section.
- Dropped a stale `cloud.comfy.org` reference — the v2 API is served at `api.comfy.org`.

## Verified

Confirmed against the installed CLI (`--help` shows only flags; `start` is rejected) and PyPI (`comfy-api-proxy` 0.1.1 is live, so the `pip install` line is correct). Docs-only; the CI matrix claim (3.10–3.12) is accurate and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)