### PR TITLE
docs: point SDK references at the renamed repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ one before running the demo:
 ```
 some-parent-dir/
 ├── comfy-api-proxy/   (this repo)
-└── ComfyPythonSDK/
+└── comfy-python-sdk/
 ```
 
 CI never depends on that checkout being present: the test suite
@@ -200,8 +200,8 @@ Any real integration — and `demo/run_demo.py` — uses the same client SDKs
 Comfy Cloud users use, just pointed at this proxy's `--host:--port` instead
 of `api.comfy.org`:
 
-- [ComfyPythonSDK](https://github.com/Comfy-Org/ComfyPythonSDK)
-- [ComfyTypeScriptSDK](https://github.com/Comfy-Org/ComfyTypeScriptSDK)
+- [comfy-python-sdk](https://github.com/Comfy-Org/comfy-python-sdk) (`comfy-sdk`)
+- [comfy-typescript-sdk](https://github.com/Comfy-Org/comfy-typescript-sdk) (`@comfyorg/sdk`)
 
 `spec/openapi.yaml` in this repo is a synced, filtered copy of that same
 Comfy API v2 contract — see `spec/README.md` for what "filtered" means, and

--- a/demo/run_demo.py
+++ b/demo/run_demo.py
@@ -16,7 +16,7 @@ import sys
 from pathlib import Path
 
 # Make the demo self-contained: import the SDK from the sibling repo checkout.
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "ComfyPythonSDK"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "comfy-python-sdk"))
 from comfy_sdk import Comfy  # noqa: E402
 
 # A minimal API-format workflow. The fake ComfyUI ignores the content and

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -8,7 +8,7 @@ status, download the output - using nothing but the Python standard library
 confirms it *runs*.
 
 This deliberately does NOT use ``demo/run_demo.py`` or the ``comfy_sdk``
-package: that SDK lives in a separate, private repo (Comfy-Org/ComfyPythonSDK),
+package: that SDK lives in a separate repo (Comfy-Org/comfy-python-sdk),
 and this repo's CI must not depend on another repo's credentials to pass.
 ``demo/run_demo.py`` remains the human-facing demo for people who have that SDK
 installed; this test is the self-contained check CI actually runs.


### PR DESCRIPTION
The SDK repos were renamed for org naming consistency (`comfy-lower-kebab-case`):

- `Comfy-Org/ComfyPythonSDK` → `Comfy-Org/comfy-python-sdk`
- `Comfy-Org/ComfyTypeScriptSDK` → `Comfy-Org/comfy-typescript-sdk`

## What changed

- `demo/run_demo.py` — the sibling-checkout path appended to `sys.path` is a literal directory name, so it had to follow the rename for the demo to find a freshly-cloned SDK.
- `README.md` — the expected directory tree and the two SDK links.
- `tests/test_smoke.py` — docstring. While updating the name I also corrected the claim that the Python SDK "lives in a separate, **private** repo"; it is public. The surrounding reasoning (CI must not depend on another repo) is unchanged and still correct.

## Risk

Docs and comments, plus one demo-only path string. No proxy behavior changes — `tests/test_smoke.py` deliberately does not import the SDK, so the suite is unaffected.

I could not run `pytest` locally (not installed in this environment); both touched Python files compile clean and CI runs the real suite.