### PR TITLE
fix: make .coderabbit.yaml valid so the repo config is actually used

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,13 +2,8 @@
 language: "en-US"
 early_access: false
 tone_instructions: |
-  This is a Python/aiohttp service (comfy-api-proxy). CI already runs
-  `ruff check`, `ruff format --check`, and `mypy` on every PR — do not repeat
-  their findings or nitpick style/formatting. Focus on correctness, security
-  (no hardcoded credentials or upstream URLs), async/await handling, and
-  error propagation between the proxy and its upstream. Only comment on
-  issues introduced by this PR's changes; do not flag pre-existing problems
-  in moved, re-indented, or reformatted code.
+  Direct and technical. Lead with the concrete risk or breakage, not praise.
+  No compliments or filler — if a change is fine, say nothing.
 
 reviews:
   profile: "assertive"
@@ -34,6 +29,16 @@ reviews:
     - "!.venv/**"
 
   path_instructions:
+    # Repo-wide review rules. These used to live in `tone_instructions`, but
+    # that field is capped at 250 characters by the CodeRabbit schema, which
+    # silently invalidated this whole file.
+    - path: "**"
+      instructions: |
+        CI already runs `ruff check`, `ruff format --check`, and `mypy` on
+        every PR — do not repeat their findings or nitpick style/formatting.
+
+        Only comment on issues introduced by this PR's changes; do not flag
+        pre-existing problems in moved, re-indented, or reformatted code.
     - path: "src/comfy_api_proxy/**"
       instructions: |
         Core proxy service code. Focus on:


### PR DESCRIPTION
## The bug

`tone_instructions` is capped at **250 characters** by the CodeRabbit schema. This file held **478**, so the entire config failed validation — and CodeRabbit silently fell back to org-level UI settings rather than erroring. Recent reviews on this repo confirm it:

> **Configuration used**: Organization UI

So none of the reviewer guidance in this file has ever taken effect.

Verified against `https://coderabbit.ai/integrations/schema.v2.json` with `jsonschema`:

```
tone_instructions                         maxLength:   250
reviews.path_instructions[].instructions  maxLength: 20000
```

```
before: 1 schema error  (tone_instructions: 478 > 250)
after:  0 schema errors (tone_instructions: 136)
```

That single field was the *only* error in the file.

## Evidence this is the real cause

Comparing `tone_instructions` length against the config source CodeRabbit reports, across repos:

| Repo | `tone_instructions` | `Configuration used` |
|---|---|---|
| `cloud` | 210 (≤250) | **`Path: .coderabbit.yaml`** |
| `comfy-api-proxy` (this repo) | 478 | `Organization UI` |
| `comfy-python-sdk` | 539 | `Organization UI` |
| `comfy-typescript-sdk` | 509 | `Organization UI` |

The correlation is exact, and `cloud` shows repo config *can* win — so this isn't the org UI unconditionally overriding.

## The fix

The schema describes `tone_instructions` as a persona field — *"Set the tone of reviews and chat"* — not a place for substantive review rules. So rather than deleting guidance to fit under the cap, the repo-wide rules move to a `path: "**"` entry, which has 20000 characters of room.

**No guidance is lost:**

| Old `tone_instructions` clause | Where it lives now |
|---|---|
| Don't repeat ruff/mypy findings, don't nitpick style | new `**` path_instruction |
| Only flag issues this PR introduces, not pre-existing code | new `**` path_instruction |
| No hardcoded credentials or upstream URLs | already in `src/comfy_api_proxy/**` (unchanged) |
| Async/await correctness | already in `src/comfy_api_proxy/**` (unchanged) |
| Error propagation to/from upstream | already in `src/comfy_api_proxy/**` (unchanged) |

## Verifying the fix

Note this PR **cannot** confirm the fix itself — CodeRabbit reads `.coderabbit.yaml` from the PR's base branch, so `main`'s broken copy is what it loads here. Confirmation comes from the first review on `main` after this merges, which should report `Path: .coderabbit.yaml`.

Same fix is up for `comfy-python-sdk` and `comfy-typescript-sdk`.