### PR TITLE
feat: allowlisted CORS for browser access to local proxy

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+# CLA Assistant requires `pull_request_target` so it can comment on fork PRs
+# and write CLA signatures with elevated permissions. The workflow does not
+# check out untrusted PR code; only GitHub API calls + the pinned CLA action.
+rules:
+  dangerous-triggers:
+    ignore:
+      - cla.yml

--- a/README.md
+++ b/README.md
@@ -191,7 +191,9 @@ configuration:
 - **A default-on origin-check middleware** — ported from ComfyUI core's own
   `create_origin_only_middleware` — rejects cross-site browser requests even
   when nothing else is configured, closing the DNS-rebinding / drive-by-CSRF
-  hole any unauthenticated localhost server is exposed to.
+  hole any unauthenticated localhost server is exposed to. Opt in a hosted
+  web app with `--enable-cors-header <origin>` (repeatable; `*` refused) —
+  see [Browser access](docs/browser-access.md).
 - **Model-file uploads are safetensors-only, with path-traversal and
   symlink-escape guards** (see *Model-file uploads* above) — and are
   rejected outright unless the proxy was started co-located with
@@ -212,6 +214,19 @@ comfy-api-proxy --comfyui http://127.0.0.1:8188 --port 8189 [options]
 | `--comfyui-base-dir` | *(unset)* | Filesystem root of a co-located ComfyUI install. Required to enable direct model-directory placement of model-file uploads; without it, model uploads are rejected (workflow-input uploads still work). |
 | `--max-upload-mb` | `100` | Max single-request upload size, in MB. |
 | `--allow-insecure-bind` | `false` | Permit binding a non-loopback `--host` without a `--token`. Unsafe — exposes an unauthenticated proxy to the network. |
+| `--enable-cors-header` | *(unset)* | Allow a browser `Origin` to call this proxy (repeatable). Explicit origins only — `*` is refused. See [Browser access](docs/browser-access.md). |
+
+## Browser access (hosted origin → local proxy)
+
+```bash
+comfy-api-proxy --enable-cors-header https://your-app.example --token "$LOCAL_PROXY_TOKEN"
+```
+
+Enables CORS preflight, `Authorization` / `Idempotency-Key`, exposes
+`Retry-After` / range headers, and makes `GET /api/v2/health` readable from
+the allowlisted Origin. `@comfyorg/sdk` stays Node-only for v1 — browser apps
+should use `fetch` against `/api/v2/*`. Details:
+[docs/browser-access.md](docs/browser-access.md).
 
 ## SDKs and the API contract
 

--- a/docs/browser-access.md
+++ b/docs/browser-access.md
@@ -17,9 +17,8 @@ comfy-api-proxy \
 - Allowlisted Origins get CORS preflight (`OPTIONS` → `204`), may send
   `Authorization` / `Content-Type` / `Idempotency-Key`, and can read
   `Retry-After`, `Content-Range`, and `Accept-Ranges` on responses.
-- `GET /api/v2/health` is readable cross-origin when the Origin is allowlisted
-  (still requires `--token` if configured). Streaming responses (SSE) get the
-  same CORS headers via `on_response_prepare`.
+- `GET /api/v2/health` is readable cross-origin when the Origin is allowlisted.
+  Streaming responses (SSE) get the same CORS headers via `on_response_prepare`.
 - Non-allowlisted Origins keep today's `403 forbidden_origin` behaviour.
 
 ## Security posture

--- a/docs/browser-access.md
+++ b/docs/browser-access.md
@@ -1,0 +1,41 @@
+# Browser access to a local proxy
+
+Hosted web apps can call a user's local `comfy-api-proxy` on `127.0.0.1` after
+the user allowlists their Origin. Cross-site browser access is **off by
+default** (DNS-rebinding / CSRF guard ported from ComfyUI core).
+
+## Configure
+
+```bash
+comfy-api-proxy \
+  --enable-cors-header https://app.example.com \
+  --token "$LOCAL_PROXY_TOKEN"   # optional; recommended
+```
+
+- `--enable-cors-header` is repeatable. Explicit `http(s)://host[:port]` only —
+  `*` is refused.
+- Allowlisted Origins get CORS preflight (`OPTIONS` → `204`), may send
+  `Authorization` / `Content-Type` / `Idempotency-Key`, and can read
+  `Retry-After`, `Content-Range`, and `Accept-Ranges` on responses.
+- `GET /api/v2/health` is readable cross-origin when the Origin is allowlisted
+  (still requires `--token` if configured). Streaming responses (SSE) get the
+  same CORS headers via `on_response_prepare`.
+- Non-allowlisted Origins keep today's `403 forbidden_origin` behaviour.
+
+## Security posture
+
+The allowlist does the anti-CSRF work: attacker Origins are not listed.
+`--token` is an extra local lock (useful when widening `--host`); for a
+loopback-only single-user setup it is not a Cloud-grade secret.
+
+## TypeScript / browser clients
+
+`@comfyorg/sdk` is **Node-only for v1** (browser support is out of scope).
+Call `/api/v2/*` with `fetch` against the proxy base URL. A browser SDK build
+is a follow-up, not required to use this path.
+
+```js
+const r = await fetch("http://127.0.0.1:8189/api/v2/health", {
+  headers: { Authorization: `Bearer ${token}` }, // omit if no --token
+});
+```

--- a/docs/browser-access.md
+++ b/docs/browser-access.md
@@ -19,7 +19,10 @@ comfy-api-proxy \
   `Retry-After`, `Content-Range`, and `Accept-Ranges` on responses.
 - `GET /api/v2/health` is readable cross-origin when the Origin is allowlisted.
   Streaming responses (SSE) get the same CORS headers via `on_response_prepare`.
-- Non-allowlisted Origins keep today's `403 forbidden_origin` behaviour.
+- Non-allowlisted Origins keep today's `403 forbidden_origin` behaviour when
+  the request is cross-site or its `Origin` disagrees with a loopback `Host`.
+  A same-origin request is unaffected — the guard exists to stop cross-site
+  callers, not to require an allowlist entry for the proxy's own page.
 
 ## Security posture
 

--- a/src/comfy_api_proxy/auth.py
+++ b/src/comfy_api_proxy/auth.py
@@ -35,6 +35,10 @@ def make_bearer_auth_middleware(token: str) -> Middleware:
     async def bearer_auth_middleware(request: web.Request, handler: Handler) -> web.StreamResponse:
         if not request.path.startswith("/api/v2/"):
             return await handler(request)
+        # Browser CORS preflight never carries Authorization; allow OPTIONS
+        # through so an allowlisted origin can negotiate before the real call.
+        if request.method == "OPTIONS":
+            return await handler(request)
         header = request.headers.get("Authorization", "")
         scheme, _, presented = header.partition(" ")
         if scheme.lower() != "bearer" or not presented:

--- a/src/comfy_api_proxy/cli.py
+++ b/src/comfy_api_proxy/cli.py
@@ -1,14 +1,4 @@
-"""Command-line entry point.
-
-Usage:
-
-  * ``comfy-api-proxy`` / ``comfy-api-proxy run`` — run in the foreground
-    (Ctrl+C to stop). A bare invocation with flags is treated as ``run`` for
-    backward compatibility.
-  * ``comfy-api-proxy start`` — start in the background (detached); prints the
-    URL and returns.
-  * ``comfy-api-proxy stop`` — stop the background proxy.
-  * ``comfy-api-proxy status`` — report whether the background proxy is running.
+"""Command-line entry point: ``comfy-api-proxy --comfyui URL --port N``.
 
 Security posture (the defaults are the safety net):
 
@@ -19,6 +9,9 @@ Security posture (the defaults are the safety net):
   * The default-on origin guard (ported from ComfyUI core) is always wired
     in, matching ComfyUI's own default; a static bearer token gates
     ``/api/v2/*`` when configured.
+  * ``--enable-cors-header <origin>`` (repeatable) is the opt-in browser
+    escape hatch: allowlisted Origins may call the loopback proxy; ``*`` is
+    refused.
 """
 
 from __future__ import annotations
@@ -29,12 +22,14 @@ import sys
 
 from aiohttp import web
 
-from . import service
 from .app import _DEFAULT_MAX_UPLOAD_BYTES, make_app
 from .auth import make_bearer_auth_middleware
-from .middleware import origin_only_middleware
-
-_COMMANDS = {"run", "start", "stop", "status"}
+from .middleware import (
+    attach_cors_prepare,
+    make_cors_middleware,
+    make_origin_only_middleware,
+    normalize_cors_origin,
+)
 
 
 def _is_loopback_host(host: str) -> bool:
@@ -50,7 +45,8 @@ def _is_loopback_host(host: str) -> bool:
         return host == "localhost"
 
 
-def _add_server_args(parser: argparse.ArgumentParser) -> None:
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="comfy-api-proxy")
     parser.add_argument(
         "--comfyui",
         default="http://127.0.0.1:8188",
@@ -91,85 +87,52 @@ def _add_server_args(parser: argparse.ArgumentParser) -> None:
         help="Permit binding a non-loopback --host without a --token. Unsafe: "
         "exposes an unauthenticated proxy to the network.",
     )
+    parser.add_argument(
+        "--enable-cors-header",
+        action="append",
+        default=[],
+        metavar="ORIGIN",
+        dest="cors_origins",
+        help="Allow a browser Origin to call this proxy (repeatable). Pass an "
+        "explicit origin such as https://app.example.com. Unlike ComfyUI "
+        "core, '*' is refused — see docs/browser-access.md.",
+    )
+    args = parser.parse_args(argv)
 
-
-def _bind_refused(args: argparse.Namespace) -> bool:
     if not _is_loopback_host(args.host) and not args.token and not args.allow_insecure_bind:
         print(
             f"refusing to bind non-loopback host {args.host!r} without --token "
             "(pass --allow-insecure-bind to override).",
             file=sys.stderr,
         )
-        return True
-    return False
-
-
-def _run_foreground(args: argparse.Namespace) -> int:
-    if _bind_refused(args):
         return 2
-    middlewares: list = [origin_only_middleware]
+
+    cors_origins: list[str] = []
+    for raw in args.cors_origins:
+        try:
+            cors_origins.append(normalize_cors_origin(raw))
+        except ValueError as exc:
+            print(f"invalid --enable-cors-header: {exc}", file=sys.stderr)
+            return 2
+
+    # Outermost first: CORS (preflight + headers) → origin guard → optional auth.
+    middlewares: list = []
+    if cors_origins:
+        middlewares.append(make_cors_middleware(cors_origins))
+    middlewares.append(make_origin_only_middleware(cors_origins))
     if args.token:
         middlewares.append(make_bearer_auth_middleware(args.token))
+
     app = make_app(
         args.comfyui,
         comfyui_base_dir=args.comfyui_base_dir,
         max_upload_bytes=args.max_upload_mb * 1024 * 1024,
         middlewares=middlewares,
     )
+    if cors_origins:
+        attach_cors_prepare(app)
     web.run_app(app, host=args.host, port=args.port)
     return 0
-
-
-def _server_argv(args: argparse.Namespace) -> list[str]:
-    """Reconstruct the run flags to hand to a detached child process."""
-    argv = [
-        "--comfyui",
-        args.comfyui,
-        "--host",
-        args.host,
-        "--port",
-        str(args.port),
-        "--max-upload-mb",
-        str(args.max_upload_mb),
-    ]
-    if args.token:
-        argv += ["--token", args.token]
-    if args.comfyui_base_dir:
-        argv += ["--comfyui-base-dir", args.comfyui_base_dir]
-    if args.allow_insecure_bind:
-        argv += ["--allow-insecure-bind"]
-    return argv
-
-
-def main(argv: list[str] | None = None) -> int:
-    raw = list(sys.argv[1:] if argv is None else argv)
-    # Backward compatibility: a bare invocation (no subcommand, or leading flags)
-    # runs in the foreground, same as the original single-command CLI.
-    if not raw or (raw[0] not in _COMMANDS and raw[0] not in ("-h", "--help")):
-        raw = ["run", *raw]
-
-    parser = argparse.ArgumentParser(prog="comfy-api-proxy")
-    sub = parser.add_subparsers(dest="command", required=True)
-    run_p = sub.add_parser("run", help="Run in the foreground (Ctrl+C to stop).")
-    _add_server_args(run_p)
-    start_p = sub.add_parser("start", help="Start the proxy in the background.")
-    _add_server_args(start_p)
-    sub.add_parser("stop", help="Stop the background proxy.")
-    sub.add_parser("status", help="Show whether the background proxy is running.")
-
-    args = parser.parse_args(raw)
-
-    if args.command == "run":
-        return _run_foreground(args)
-    if args.command == "start":
-        if _bind_refused(args):
-            return 2
-        return service.start(_server_argv(args), args.host, args.port)
-    if args.command == "stop":
-        return service.stop()
-    if args.command == "status":
-        return service.status()
-    return 2  # unreachable (subparser is required)
 
 
 if __name__ == "__main__":

--- a/src/comfy_api_proxy/cli.py
+++ b/src/comfy_api_proxy/cli.py
@@ -1,4 +1,14 @@
-"""Command-line entry point: ``comfy-api-proxy --comfyui URL --port N``.
+"""Command-line entry point.
+
+Usage:
+
+  * ``comfy-api-proxy`` / ``comfy-api-proxy run`` — run in the foreground
+    (Ctrl+C to stop). A bare invocation with flags is treated as ``run`` for
+    backward compatibility.
+  * ``comfy-api-proxy start`` — start in the background (detached); prints the
+    URL and returns.
+  * ``comfy-api-proxy stop`` — stop the background proxy.
+  * ``comfy-api-proxy status`` — report whether the background proxy is running.
 
 Security posture (the defaults are the safety net):
 
@@ -22,6 +32,7 @@ import sys
 
 from aiohttp import web
 
+from . import service
 from .app import _DEFAULT_MAX_UPLOAD_BYTES, make_app
 from .auth import make_bearer_auth_middleware
 from .middleware import (
@@ -30,6 +41,8 @@ from .middleware import (
     make_origin_only_middleware,
     normalize_cors_origin,
 )
+
+_COMMANDS = {"run", "start", "stop", "status"}
 
 
 def _is_loopback_host(host: str) -> bool:
@@ -45,8 +58,7 @@ def _is_loopback_host(host: str) -> bool:
         return host == "localhost"
 
 
-def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(prog="comfy-api-proxy")
+def _add_server_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--comfyui",
         default="http://127.0.0.1:8188",
@@ -97,23 +109,37 @@ def main(argv: list[str] | None = None) -> int:
         "explicit origin such as https://app.example.com. Unlike ComfyUI "
         "core, '*' is refused — see docs/browser-access.md.",
     )
-    args = parser.parse_args(argv)
 
+
+def _bind_refused(args: argparse.Namespace) -> bool:
     if not _is_loopback_host(args.host) and not args.token and not args.allow_insecure_bind:
         print(
             f"refusing to bind non-loopback host {args.host!r} without --token "
             "(pass --allow-insecure-bind to override).",
             file=sys.stderr,
         )
-        return 2
+        return True
+    return False
 
+
+def _parse_cors_origins(raw_origins: list[str]) -> list[str] | None:
+    """Normalize allowlisted origins, or print and return None on error."""
     cors_origins: list[str] = []
-    for raw in args.cors_origins:
+    for raw in raw_origins:
         try:
             cors_origins.append(normalize_cors_origin(raw))
         except ValueError as exc:
             print(f"invalid --enable-cors-header: {exc}", file=sys.stderr)
-            return 2
+            return None
+    return cors_origins
+
+
+def _run_foreground(args: argparse.Namespace) -> int:
+    if _bind_refused(args):
+        return 2
+    cors_origins = _parse_cors_origins(args.cors_origins)
+    if cors_origins is None:
+        return 2
 
     # Outermost first: CORS (preflight + headers) → origin guard → optional auth.
     middlewares: list = []
@@ -133,6 +159,62 @@ def main(argv: list[str] | None = None) -> int:
         attach_cors_prepare(app)
     web.run_app(app, host=args.host, port=args.port)
     return 0
+
+
+def _server_argv(args: argparse.Namespace) -> list[str]:
+    """Reconstruct the run flags to hand to a detached child process."""
+    argv = [
+        "--comfyui",
+        args.comfyui,
+        "--host",
+        args.host,
+        "--port",
+        str(args.port),
+        "--max-upload-mb",
+        str(args.max_upload_mb),
+    ]
+    if args.token:
+        argv += ["--token", args.token]
+    if args.comfyui_base_dir:
+        argv += ["--comfyui-base-dir", args.comfyui_base_dir]
+    if args.allow_insecure_bind:
+        argv += ["--allow-insecure-bind"]
+    for origin in args.cors_origins:
+        argv += ["--enable-cors-header", origin]
+    return argv
+
+
+def main(argv: list[str] | None = None) -> int:
+    raw = list(sys.argv[1:] if argv is None else argv)
+    # Backward compatibility: a bare invocation (no subcommand, or leading flags)
+    # runs in the foreground, same as the original single-command CLI.
+    if not raw or (raw[0] not in _COMMANDS and raw[0] not in ("-h", "--help")):
+        raw = ["run", *raw]
+
+    parser = argparse.ArgumentParser(prog="comfy-api-proxy")
+    sub = parser.add_subparsers(dest="command", required=True)
+    run_p = sub.add_parser("run", help="Run in the foreground (Ctrl+C to stop).")
+    _add_server_args(run_p)
+    start_p = sub.add_parser("start", help="Start the proxy in the background.")
+    _add_server_args(start_p)
+    sub.add_parser("stop", help="Stop the background proxy.")
+    sub.add_parser("status", help="Show whether the background proxy is running.")
+
+    args = parser.parse_args(raw)
+
+    if args.command == "run":
+        return _run_foreground(args)
+    if args.command == "start":
+        if _bind_refused(args):
+            return 2
+        if _parse_cors_origins(args.cors_origins) is None:
+            return 2
+        return service.start(_server_argv(args), args.host, args.port)
+    if args.command == "stop":
+        return service.stop()
+    if args.command == "status":
+        return service.status()
+    return 2  # unreachable (subparser is required)
 
 
 if __name__ == "__main__":

--- a/src/comfy_api_proxy/middleware.py
+++ b/src/comfy_api_proxy/middleware.py
@@ -1,6 +1,9 @@
-"""Default-on request-origin guard, ported from ComfyUI core's
-``create_origin_only_middleware`` (``server.py``, verified against that
-file directly).
+"""Request-origin guard and opt-in CORS for browser clients.
+
+Default-on origin guard
+-----------------------
+Ported from ComfyUI core's ``create_origin_only_middleware`` (``server.py``,
+verified against that file directly).
 
 ComfyUI's own server applies this by default (it can be turned off with
 ``--enable-cors-header``) because a local, unauthenticated-by-default
@@ -28,6 +31,16 @@ A request with **no** ``Origin`` header at all (curl, the SDK, server-to-
 server calls) is let through unchanged by check 2 — browsers always send
 ``Origin`` for the cross-site requests this guard exists to stop, so
 requiring one would only break legitimate non-browser clients.
+
+Opt-in CORS allowlist
+---------------------
+``--enable-cors-header <origin>`` (repeatable) is the escape hatch for a
+hosted web app that calls a user's local proxy. Unlike ComfyUI core, this
+proxy **refuses** ``*`` — only explicit origins are accepted — so
+authenticated / credentialed browser requests never get an unrestricted
+``Access-Control-Allow-Origin``. An allowlisted Origin bypasses the
+origin-only checks above and receives CORS response headers (including on
+preflight ``OPTIONS`` and on ``GET /api/v2/health``).
 """
 
 from __future__ import annotations
@@ -35,9 +48,19 @@ from __future__ import annotations
 import ipaddress
 import socket
 import urllib.parse
+from collections.abc import Collection
 
 from aiohttp import web
-from aiohttp.typedefs import Handler
+from aiohttp.typedefs import Handler, Middleware
+
+# Stashed on the request by CORS middleware; read by on_response_prepare.
+_CORS_ORIGIN_KEY = "cors_allowed_origin"
+
+CORS_ALLOW_METHODS = "GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS"
+CORS_ALLOW_HEADERS = "Authorization, Content-Type, Idempotency-Key"
+# Response headers a browser client may need to read after a cross-origin call.
+CORS_EXPOSE_HEADERS = "Retry-After, Content-Range, Accept-Ranges"
+CORS_MAX_AGE = "600"
 
 
 def _forbidden(message: str) -> web.Response:
@@ -75,33 +98,132 @@ def _is_loopback(host: str | None) -> bool:
     return loopback
 
 
-@web.middleware
-async def origin_only_middleware(request: web.Request, handler: Handler) -> web.StreamResponse:
-    if request.headers.get("Sec-Fetch-Site") == "cross-site":
-        return _forbidden("Cross-site request blocked (Sec-Fetch-Site: cross-site).")
+def normalize_cors_origin(value: str) -> str:
+    """Validate and normalize a single ``--enable-cors-header`` value.
 
-    host_header = request.headers.get("Host")
-    origin_header = request.headers.get("Origin")
-    if host_header and origin_header:
-        parsed_origin = urllib.parse.urlparse(origin_header)
-        origin_domain = parsed_origin.netloc.lower()
-        host_domain = host_header.lower()
-        host_domain_parsed = urllib.parse.urlsplit("//" + host_domain)
+    Accepts ``http(s)://host[:port]`` only. Trailing slashes are stripped.
+    ``*`` is refused — authenticated browser traffic must never get an
+    unrestricted wildcard ACAO.
+    """
+    raw = value.strip()
+    if not raw:
+        raise ValueError("CORS origin must be a non-empty http(s) URL.")
+    if raw == "*":
+        raise ValueError(
+            "CORS origin '*' is not allowed; pass explicit origins "
+            "(e.g. https://app.example.com). Unrestricted wildcards are "
+            "unsafe for authenticated or credentialed browser requests."
+        )
+    parsed = urllib.parse.urlparse(raw)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise ValueError(
+            f"CORS origin must be an absolute http(s) URL with a host, got {value!r}."
+        )
+    if parsed.path not in ("", "/") or parsed.params or parsed.query or parsed.fragment:
+        raise ValueError(
+            f"CORS origin must not include a path, query, or fragment, got {value!r}."
+        )
+    return f"{parsed.scheme}://{parsed.netloc}"
 
-        # Scoped to loopback hosts only (matches upstream): a real,
-        # non-loopback deployment may sit behind a reverse proxy that
-        # legitimately rewrites Host, which this check must not break.
-        if _is_loopback(host_domain_parsed.hostname):
-            if parsed_origin.port is None:
-                host_domain = host_domain_parsed.hostname or host_domain
-            if host_domain_parsed.port is None:
-                origin_domain = parsed_origin.hostname or origin_domain
 
-            if host_domain and origin_domain and host_domain != origin_domain:
-                return _forbidden(
-                    f"Origin '{origin_header}' does not match request host '{host_header}'."
-                )
+def apply_cors_headers(response: web.StreamResponse, origin: str) -> None:
+    """Attach CORS headers for an exact allowlisted origin (never ``*``)."""
+    response.headers["Access-Control-Allow-Origin"] = origin
+    existing_vary = response.headers.get("Vary")
+    if existing_vary is None:
+        response.headers["Vary"] = "Origin"
+    elif "Origin" not in {part.strip() for part in existing_vary.split(",")}:
+        response.headers["Vary"] = f"{existing_vary}, Origin"
+    response.headers["Access-Control-Allow-Methods"] = CORS_ALLOW_METHODS
+    response.headers["Access-Control-Allow-Headers"] = CORS_ALLOW_HEADERS
+    response.headers["Access-Control-Expose-Headers"] = CORS_EXPOSE_HEADERS
+    response.headers["Access-Control-Allow-Credentials"] = "true"
+    response.headers["Access-Control-Max-Age"] = CORS_MAX_AGE
 
-    if request.method == "OPTIONS":
-        return web.Response()
-    return await handler(request)
+
+def make_cors_middleware(allowed_origins: Collection[str]) -> Middleware:
+    """Emit CORS headers for allowlisted Origins; answer OPTIONS preflight.
+
+    Non-allowlisted Origins are untouched (and still face the origin-only
+    guard). Register :func:`attach_cors_prepare` on the app so streaming
+    responses (SSE) also get headers before they are prepared.
+    """
+    allowed = frozenset(normalize_cors_origin(o) for o in allowed_origins)
+    if not allowed:
+        raise ValueError("make_cors_middleware requires at least one origin.")
+
+    @web.middleware
+    async def cors_middleware(request: web.Request, handler: Handler) -> web.StreamResponse:
+        origin = request.headers.get("Origin")
+        if origin and origin in allowed:
+            request[_CORS_ORIGIN_KEY] = origin
+            if request.method == "OPTIONS":
+                # Preflight — no body, no auth. Headers land via on_response_prepare.
+                return web.Response(status=204)
+        return await handler(request)
+
+    return cors_middleware
+
+
+def attach_cors_prepare(app: web.Application) -> None:
+    """Apply stashed CORS headers before any response (including streams) is sent."""
+
+    async def _on_prepare(request: web.Request, response: web.StreamResponse) -> None:
+        origin = request.get(_CORS_ORIGIN_KEY)
+        if origin:
+            apply_cors_headers(response, origin)
+
+    app.on_response_prepare.append(_on_prepare)
+
+
+def make_origin_only_middleware(allowed_origins: Collection[str] = ()) -> Middleware:
+    """Build the default-on origin guard, with optional allowlist bypass.
+
+    Origins in ``allowed_origins`` skip both the ``Sec-Fetch-Site`` and the
+    Host/Origin mismatch checks so an operator-configured hosted app can
+    reach a loopback proxy. Everything else keeps the ComfyUI-core behaviour.
+    """
+    allowed = frozenset(normalize_cors_origin(o) for o in allowed_origins)
+
+    @web.middleware
+    async def origin_only_middleware(request: web.Request, handler: Handler) -> web.StreamResponse:
+        origin_header = request.headers.get("Origin")
+        if origin_header and origin_header in allowed:
+            if request.method == "OPTIONS":
+                return web.Response(status=204)
+            return await handler(request)
+
+        if request.headers.get("Sec-Fetch-Site") == "cross-site":
+            return _forbidden("Cross-site request blocked (Sec-Fetch-Site: cross-site).")
+
+        host_header = request.headers.get("Host")
+        if host_header and origin_header:
+            parsed_origin = urllib.parse.urlparse(origin_header)
+            origin_domain = parsed_origin.netloc.lower()
+            host_domain = host_header.lower()
+            host_domain_parsed = urllib.parse.urlsplit("//" + host_domain)
+
+            # Scoped to loopback hosts only (matches upstream): a real,
+            # non-loopback deployment may sit behind a reverse proxy that
+            # legitimately rewrites Host, which this check must not break.
+            if _is_loopback(host_domain_parsed.hostname):
+                if parsed_origin.port is None:
+                    host_domain = host_domain_parsed.hostname or host_domain
+                if host_domain_parsed.port is None:
+                    origin_domain = parsed_origin.hostname or origin_domain
+
+                if host_domain and origin_domain and host_domain != origin_domain:
+                    return _forbidden(
+                        f"Origin '{origin_header}' does not match request host '{host_header}'."
+                    )
+
+        if request.method == "OPTIONS":
+            return web.Response()
+        return await handler(request)
+
+    return origin_only_middleware
+
+
+# Default instance: no allowlist (preserves import sites / tests that use the
+# module-level name directly).
+origin_only_middleware = make_origin_only_middleware()

--- a/src/comfy_api_proxy/middleware.py
+++ b/src/comfy_api_proxy/middleware.py
@@ -102,8 +102,10 @@ def normalize_cors_origin(value: str) -> str:
     """Validate and normalize a single ``--enable-cors-header`` value.
 
     Accepts ``http(s)://host[:port]`` only. Trailing slashes are stripped.
-    ``*`` is refused — authenticated browser traffic must never get an
-    unrestricted wildcard ACAO.
+    Userinfo and malformed/empty ports are rejected. Default ports (80 for
+    http, 443 for https) are omitted so allowlist matching matches browser
+    ``Origin`` headers. ``*`` is refused — authenticated browser traffic
+    must never get an unrestricted wildcard ACAO.
     """
     raw = value.strip()
     if not raw:
@@ -116,14 +118,31 @@ def normalize_cors_origin(value: str) -> str:
         )
     parsed = urllib.parse.urlparse(raw)
     if parsed.scheme not in ("http", "https") or not parsed.netloc:
-        raise ValueError(
-            f"CORS origin must be an absolute http(s) URL with a host, got {value!r}."
-        )
+        raise ValueError(f"CORS origin must be an absolute http(s) URL with a host, got {value!r}.")
+    if parsed.username is not None or parsed.password is not None or "@" in parsed.netloc:
+        raise ValueError(f"CORS origin must not include userinfo, got {value!r}.")
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError(f"CORS origin must be an absolute http(s) URL with a host, got {value!r}.")
+    # Empty port (``http://host:``) leaves ``port`` as None but keeps the colon.
+    authority = parsed.netloc.rsplit("@", 1)[-1]
+    if authority.endswith(":"):
+        raise ValueError(f"CORS origin has an empty port, got {value!r}.")
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError(f"CORS origin has an invalid port, got {value!r}.") from exc
     if parsed.path not in ("", "/") or parsed.params or parsed.query or parsed.fragment:
-        raise ValueError(
-            f"CORS origin must not include a path, query, or fragment, got {value!r}."
-        )
-    return f"{parsed.scheme}://{parsed.netloc}"
+        raise ValueError(f"CORS origin must not include a path, query, or fragment, got {value!r}.")
+    # Reconstruct from validated host/port (not raw netloc) for a stable allowlist key.
+    host = f"[{hostname}]" if ":" in hostname else hostname
+    if (
+        port is None
+        or (parsed.scheme == "http" and port == 80)
+        or (parsed.scheme == "https" and port == 443)
+    ):
+        return f"{parsed.scheme}://{host}"
+    return f"{parsed.scheme}://{host}:{port}"
 
 
 def apply_cors_headers(response: web.StreamResponse, origin: str) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,20 @@ class Stack:
         *,
         headers: dict[str, str] | None = None,
     ) -> tuple[int, Any, bytes]:
+        status, parsed, raw, _resp_headers = self.request_with_headers(
+            method, path, body, headers=headers
+        )
+        return status, parsed, raw
+
+    def request_with_headers(
+        self,
+        method: str,
+        path: str,
+        body: dict[str, Any] | None = None,
+        *,
+        headers: dict[str, str] | None = None,
+    ) -> tuple[int, Any, bytes, dict[str, str]]:
+        """Like :meth:`request`, but also returns response headers (lower-cased keys)."""
         url = self.base + path if path.startswith("/") else path
         data = json.dumps(body).encode() if body is not None else None
         hdrs = dict(headers or {})
@@ -75,14 +89,14 @@ class Stack:
                 raw = r.read()
                 ctype = r.headers.get("Content-Type", "")
                 parsed = json.loads(raw) if "application/json" in ctype else None
-                return r.status, parsed, raw
+                return r.status, parsed, raw, {k.lower(): v for k, v in r.headers.items()}
         except urllib.error.HTTPError as e:
             raw = e.read()
             try:
                 parsed = json.loads(raw)
             except Exception:
                 parsed = None
-            return e.code, parsed, raw
+            return e.code, parsed, raw, {k.lower(): v for k, v in e.headers.items()}
 
     def upload(
         self, file_path: str, content: bytes, content_type: str, **fields: str
@@ -160,6 +174,7 @@ def _make_stack(
     comfyui_base_dir: str | None = None,
     token: str | None = None,
     max_upload_mb: int | None = None,
+    cors_origins: list[str] | None = None,
 ):
     """Spawn fake ComfyUI + the real proxy on free ports; yield a Stack driver."""
     procs: list[tuple[subprocess.Popen, str, Path]] = []
@@ -198,6 +213,8 @@ def _make_stack(
         proxy_args += ["--token", token]
     if max_upload_mb is not None:
         proxy_args += ["--max-upload-mb", str(max_upload_mb)]
+    for origin in cors_origins or []:
+        proxy_args += ["--enable-cors-header", origin]
     _spawn(proxy_args, proxy_port, "proxy")
 
     stack = Stack(f"http://127.0.0.1:{proxy_port}", comfyui_port, proxy_port)
@@ -257,5 +274,29 @@ def stack_with_models_dir(tmp_path) -> Any:
     s, cleanup = _make_stack(tmp_path, comfyui_base_dir=str(base_dir))
     try:
         yield s, base_dir
+    finally:
+        cleanup()
+
+
+@pytest.fixture
+def stack_with_cors(tmp_path) -> Any:
+    """Proxy with an explicit browser-origin allowlist (hosted app → localhost)."""
+    s, cleanup = _make_stack(tmp_path, cors_origins=["https://app.example.com"])
+    try:
+        yield s
+    finally:
+        cleanup()
+
+
+@pytest.fixture
+def stack_with_cors_and_token(tmp_path) -> Any:
+    """CORS allowlist plus bearer token — mirrors a hardened local browser setup."""
+    s, cleanup = _make_stack(
+        tmp_path,
+        token="secret",
+        cors_origins=["https://app.example.com"],
+    )
+    try:
+        yield s
     finally:
         cleanup()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -64,12 +64,12 @@ async def test_non_v2_path_bypasses_the_gate():
 
 
 async def test_options_preflight_bypasses_the_gate():
-    """CORS preflight never carries Authorization; the gate must not 401 it."""
-    resp, ran = await _invoke(
-        make_bearer_auth_middleware("secret"),
-        {},
-        path="/api/v2/health",
-    )
+    """CORS preflight never carries Authorization; the gate must not 401 it.
+
+    Uses a guarded job path, not /api/v2/health — health has its own
+    unauthenticated carve-out, which would mask what this asserts.
+    """
+    resp, ran = await _invoke(make_bearer_auth_middleware("secret"), {})
     # GET without token still rejects — control for the OPTIONS case below.
     assert resp.status == 401
     assert not ran
@@ -82,7 +82,7 @@ async def test_options_preflight_bypasses_the_gate():
 
     mw = make_bearer_auth_middleware("secret")
     resp = await mw(
-        make_mocked_request("OPTIONS", "/api/v2/health", headers={}),
+        make_mocked_request("OPTIONS", "/api/v2/jobs/x", headers={}),
         handler,
     )
     assert resp.status == 204

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -63,6 +63,32 @@ async def test_non_v2_path_bypasses_the_gate():
     assert ran
 
 
+async def test_options_preflight_bypasses_the_gate():
+    """CORS preflight never carries Authorization; the gate must not 401 it."""
+    resp, ran = await _invoke(
+        make_bearer_auth_middleware("secret"),
+        {},
+        path="/api/v2/health",
+    )
+    # GET without token still rejects — control for the OPTIONS case below.
+    assert resp.status == 401
+    assert not ran
+
+    called = {"v": False}
+
+    async def handler(_req):
+        called["v"] = True
+        return web.Response(status=204)
+
+    mw = make_bearer_auth_middleware("secret")
+    resp = await mw(
+        make_mocked_request("OPTIONS", "/api/v2/health", headers={}),
+        handler,
+    )
+    assert resp.status == 204
+    assert called["v"]
+
+
 def test_token_gate_enforced_end_to_end(stack_with_token):
     jid = "11111111-1111-1111-1111-111111111111"
     unauth, body, _ = stack_with_token.request("GET", f"/api/v2/jobs/{jid}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,3 +50,18 @@ def test_main_refuses_cors_origin_with_path(capsys):
     )
     assert rc == 2
     assert "invalid --enable-cors-header" in capsys.readouterr().err
+
+
+def test_main_refuses_cors_origin_with_invalid_port(capsys):
+    rc = main(
+        [
+            "--port",
+            "0",
+            "--comfyui",
+            "http://127.0.0.1:8188",
+            "--enable-cors-header",
+            "https://app.example.com:bad",
+        ]
+    )
+    assert rc == 2
+    assert "invalid --enable-cors-header" in capsys.readouterr().err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,3 +20,33 @@ def test_main_refuses_empty_host_without_token(capsys):
     rc = main(["--host", "", "--port", "0", "--comfyui", "http://127.0.0.1:8188"])
     assert rc == 2
     assert "refusing to bind" in capsys.readouterr().err
+
+
+def test_main_refuses_wildcard_cors_origin(capsys):
+    rc = main(
+        [
+            "--port",
+            "0",
+            "--comfyui",
+            "http://127.0.0.1:8188",
+            "--enable-cors-header",
+            "*",
+        ]
+    )
+    assert rc == 2
+    assert "invalid --enable-cors-header" in capsys.readouterr().err
+
+
+def test_main_refuses_cors_origin_with_path(capsys):
+    rc = main(
+        [
+            "--port",
+            "0",
+            "--comfyui",
+            "http://127.0.0.1:8188",
+            "--enable-cors-header",
+            "https://app.example.com/path",
+        ]
+    )
+    assert rc == 2
+    assert "invalid --enable-cors-header" in capsys.readouterr().err

--- a/tests/test_cors_browser.py
+++ b/tests/test_cors_browser.py
@@ -1,0 +1,151 @@
+"""Browser-origin → localhost proxy: allowlisted CORS end-to-end.
+
+Simulates a hosted web app (Origin: https://app.example.com) calling a
+proxy bound on 127.0.0.1 — the ordinaryanimator-style deployment shape
+from GitHub issue #19 / Linear BE-6449.
+"""
+
+from __future__ import annotations
+
+from comfy_api_proxy.middleware import CORS_ALLOW_HEADERS, CORS_EXPOSE_HEADERS
+
+HOSTED_ORIGIN = "https://app.example.com"
+EVIL_ORIGIN = "https://evil.example"
+
+
+def _assert_cors_headers(headers: dict[str, str], *, origin: str = HOSTED_ORIGIN) -> None:
+    assert headers.get("access-control-allow-origin") == origin
+    assert "authorization" in headers.get("access-control-allow-headers", "").lower()
+    assert "idempotency-key" in headers.get("access-control-allow-headers", "").lower()
+    assert headers.get("access-control-allow-headers") == CORS_ALLOW_HEADERS
+    assert headers.get("access-control-expose-headers") == CORS_EXPOSE_HEADERS
+    assert headers.get("access-control-allow-credentials") == "true"
+    assert "origin" in {p.strip().lower() for p in headers.get("vary", "").split(",")}
+
+
+def test_allowlisted_origin_can_preflight_and_call_health(stack_with_cors):
+    """Hosted origin: OPTIONS preflight + GET /api/v2/health are readable."""
+    status, body, raw, headers = stack_with_cors.request_with_headers(
+        "OPTIONS",
+        "/api/v2/health",
+        headers={
+            "Origin": HOSTED_ORIGIN,
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "authorization,idempotency-key",
+            "Sec-Fetch-Site": "cross-site",
+        },
+    )
+    assert status == 204, raw
+    assert body is None
+    _assert_cors_headers(headers)
+
+    status, body, raw, headers = stack_with_cors.request_with_headers(
+        "GET",
+        "/api/v2/health",
+        headers={
+            "Origin": HOSTED_ORIGIN,
+            "Sec-Fetch-Site": "cross-site",
+        },
+    )
+    assert status == 200, raw
+    assert body is not None and body.get("status") == "healthy"
+    _assert_cors_headers(headers)
+
+
+def test_allowlisted_origin_can_submit_job_with_idempotency_key(stack_with_cors):
+    """Real POST with Authorization-capable preflight headers + Idempotency-Key."""
+    status, _body, raw, headers = stack_with_cors.request_with_headers(
+        "OPTIONS",
+        "/api/v2/jobs",
+        headers={
+            "Origin": HOSTED_ORIGIN,
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "content-type,authorization,idempotency-key",
+            "Sec-Fetch-Site": "cross-site",
+        },
+    )
+    assert status == 204, raw
+    _assert_cors_headers(headers)
+
+    status, body, raw, headers = stack_with_cors.request_with_headers(
+        "POST",
+        "/api/v2/jobs",
+        {"workflow": {"1": {}}},
+        headers={
+            "Origin": HOSTED_ORIGIN,
+            "Sec-Fetch-Site": "cross-site",
+            "Idempotency-Key": "browser-e2e-1",
+        },
+    )
+    assert status == 201, (status, body, raw)
+    _assert_cors_headers(headers)
+
+
+def test_non_allowlisted_origin_is_rejected(stack_with_cors):
+    status, body, _raw, headers = stack_with_cors.request_with_headers(
+        "GET",
+        "/api/v2/health",
+        headers={
+            "Origin": EVIL_ORIGIN,
+            "Sec-Fetch-Site": "cross-site",
+        },
+    )
+    assert status == 403
+    assert body is not None and body["error"]["code"] == "forbidden_origin"
+    assert "access-control-allow-origin" not in headers
+
+
+def test_default_proxy_still_blocks_hosted_origin(stack):
+    """Without --enable-cors-header, cross-site hosted origins stay blocked."""
+    status, body, _raw, headers = stack.request_with_headers(
+        "GET",
+        "/api/v2/health",
+        headers={
+            "Origin": HOSTED_ORIGIN,
+            "Sec-Fetch-Site": "cross-site",
+        },
+    )
+    assert status == 403
+    assert body is not None and body["error"]["code"] == "forbidden_origin"
+    assert "access-control-allow-origin" not in headers
+
+
+def test_token_gate_allows_preflight_then_requires_bearer(stack_with_cors_and_token):
+    status, _body, raw, headers = stack_with_cors_and_token.request_with_headers(
+        "OPTIONS",
+        "/api/v2/health",
+        headers={
+            "Origin": HOSTED_ORIGIN,
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "authorization",
+            "Sec-Fetch-Site": "cross-site",
+        },
+    )
+    assert status == 204, raw
+    _assert_cors_headers(headers)
+
+    unauth, body, _raw, headers = stack_with_cors_and_token.request_with_headers(
+        "GET",
+        "/api/v2/health",
+        headers={
+            "Origin": HOSTED_ORIGIN,
+            "Sec-Fetch-Site": "cross-site",
+        },
+    )
+    assert unauth == 401
+    assert body is not None and body["error"]["code"] == "unauthorized"
+    # 401 must still carry CORS headers so the browser can read the error body.
+    _assert_cors_headers(headers)
+
+    ok, body, raw, headers = stack_with_cors_and_token.request_with_headers(
+        "GET",
+        "/api/v2/health",
+        headers={
+            "Origin": HOSTED_ORIGIN,
+            "Sec-Fetch-Site": "cross-site",
+            "Authorization": "Bearer secret",
+        },
+    )
+    assert ok == 200, raw
+    assert body is not None and body.get("status") == "healthy"
+    _assert_cors_headers(headers)

--- a/tests/test_cors_browser.py
+++ b/tests/test_cors_browser.py
@@ -131,9 +131,15 @@ def test_default_proxy_still_blocks_hosted_origin(stack):
 
 
 def test_token_gate_allows_preflight_then_requires_bearer(stack_with_cors_and_token):
+    """Preflight is unauthenticated; the real call still needs the bearer.
+
+    Probes a token-guarded job path rather than /api/v2/health, which is
+    deliberately readable without a credential so schedulers can poll it.
+    """
+    jid = "11111111-1111-1111-1111-111111111111"
     status, _body, raw, headers = stack_with_cors_and_token.request_with_headers(
         "OPTIONS",
-        "/api/v2/health",
+        f"/api/v2/jobs/{jid}",
         headers={
             "Origin": HOSTED_ORIGIN,
             "Access-Control-Request-Method": "GET",
@@ -146,7 +152,7 @@ def test_token_gate_allows_preflight_then_requires_bearer(stack_with_cors_and_to
 
     unauth, body, _raw, headers = stack_with_cors_and_token.request_with_headers(
         "GET",
-        "/api/v2/health",
+        f"/api/v2/jobs/{jid}",
         headers={
             "Origin": HOSTED_ORIGIN,
             "Sec-Fetch-Site": "cross-site",
@@ -157,15 +163,14 @@ def test_token_gate_allows_preflight_then_requires_bearer(stack_with_cors_and_to
     # 401 must still carry CORS headers so the browser can read the error body.
     _assert_cors_headers(headers)
 
-    ok, body, raw, headers = stack_with_cors_and_token.request_with_headers(
+    authed, _body, raw, headers = stack_with_cors_and_token.request_with_headers(
         "GET",
-        "/api/v2/health",
+        f"/api/v2/jobs/{jid}",
         headers={
             "Origin": HOSTED_ORIGIN,
             "Sec-Fetch-Site": "cross-site",
             "Authorization": "Bearer secret",
         },
     )
-    assert ok == 200, raw
-    assert body is not None and body.get("status") == "healthy"
+    assert authed != 401, raw  # past the gate (404 for the unknown job id is fine)
     _assert_cors_headers(headers)

--- a/tests/test_cors_browser.py
+++ b/tests/test_cors_browser.py
@@ -1,13 +1,10 @@
 """Browser-origin → localhost proxy: allowlisted CORS end-to-end.
 
 Simulates a hosted web app (Origin: https://app.example.com) calling a
-proxy bound on 127.0.0.1 — the ordinaryanimator-style deployment shape
-from GitHub issue #19 / Linear BE-6449.
+proxy bound on 127.0.0.1 — the ordinary hosted-web-app → local-proxy shape.
 """
 
 from __future__ import annotations
-
-from comfy_api_proxy.middleware import CORS_ALLOW_HEADERS, CORS_EXPOSE_HEADERS
 
 HOSTED_ORIGIN = "https://app.example.com"
 EVIL_ORIGIN = "https://evil.example"
@@ -15,10 +12,18 @@ EVIL_ORIGIN = "https://evil.example"
 
 def _assert_cors_headers(headers: dict[str, str], *, origin: str = HOSTED_ORIGIN) -> None:
     assert headers.get("access-control-allow-origin") == origin
-    assert "authorization" in headers.get("access-control-allow-headers", "").lower()
-    assert "idempotency-key" in headers.get("access-control-allow-headers", "").lower()
-    assert headers.get("access-control-allow-headers") == CORS_ALLOW_HEADERS
-    assert headers.get("access-control-expose-headers") == CORS_EXPOSE_HEADERS
+    allow = {
+        p.strip().lower()
+        for p in headers.get("access-control-allow-headers", "").split(",")
+        if p.strip()
+    }
+    assert {"authorization", "content-type", "idempotency-key"} <= allow
+    expose = {
+        p.strip().lower()
+        for p in headers.get("access-control-expose-headers", "").split(",")
+        if p.strip()
+    }
+    assert {"retry-after", "content-range", "accept-ranges"} <= expose
     assert headers.get("access-control-allow-credentials") == "true"
     assert "origin" in {p.strip().lower() for p in headers.get("vary", "").split(",")}
 
@@ -87,6 +92,21 @@ def test_non_allowlisted_origin_is_rejected(stack_with_cors):
         "/api/v2/health",
         headers={
             "Origin": EVIL_ORIGIN,
+            "Sec-Fetch-Site": "cross-site",
+        },
+    )
+    assert status == 403
+    assert body is not None and body["error"]["code"] == "forbidden_origin"
+    assert "access-control-allow-origin" not in headers
+
+
+def test_non_allowlisted_preflight_is_rejected(stack_with_cors):
+    status, body, _raw, headers = stack_with_cors.request_with_headers(
+        "OPTIONS",
+        "/api/v2/health",
+        headers={
+            "Origin": EVIL_ORIGIN,
+            "Access-Control-Request-Method": "GET",
             "Sec-Fetch-Site": "cross-site",
         },
     )

--- a/tests/test_cors_browser.py
+++ b/tests/test_cors_browser.py
@@ -172,5 +172,8 @@ def test_token_gate_allows_preflight_then_requires_bearer(stack_with_cors_and_to
             "Authorization": "Bearer secret",
         },
     )
-    assert authed != 401, raw  # past the gate (404 for the unknown job id is fine)
+    # Past the gate and into the handler: the job id is unknown, so the
+    # handler's own 404 is the proof — a bare "not 401" would also accept a
+    # 403 or a 500 that never reached it.
+    assert authed == 404, raw
     _assert_cors_headers(headers)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -6,7 +6,6 @@ import pytest
 from aiohttp import web
 
 from comfy_api_proxy.middleware import (
-    CORS_ALLOW_HEADERS,
     attach_cors_prepare,
     make_cors_middleware,
     make_origin_only_middleware,
@@ -24,9 +23,7 @@ def _make_app(*, cors_origins: list[str] | None = None) -> web.Application:
     middlewares = []
     if origins:
         middlewares.append(make_cors_middleware(origins))
-    middlewares.append(
-        make_origin_only_middleware(origins) if origins else origin_only_middleware
-    )
+    middlewares.append(make_origin_only_middleware(origins) if origins else origin_only_middleware)
     app = web.Application(middlewares=middlewares)
     if origins:
         attach_cors_prepare(app)
@@ -104,10 +101,12 @@ class TestCorsAllowlist:
         )
         assert resp.status == 200
         assert resp.headers["Access-Control-Allow-Origin"] == origin
-        assert resp.headers["Access-Control-Allow-Headers"] == CORS_ALLOW_HEADERS
-        assert "Retry-After" in resp.headers["Access-Control-Expose-Headers"]
-        assert "Content-Range" in resp.headers["Access-Control-Expose-Headers"]
-        assert "Accept-Ranges" in resp.headers["Access-Control-Expose-Headers"]
+        allow = {p.strip().lower() for p in resp.headers["Access-Control-Allow-Headers"].split(",")}
+        assert {"authorization", "content-type", "idempotency-key"} <= allow
+        expose = {
+            p.strip().lower() for p in resp.headers["Access-Control-Expose-Headers"].split(",")
+        }
+        assert {"retry-after", "content-range", "accept-ranges"} <= expose
 
     async def test_preflight_returns_204_with_cors_headers(self, aiohttp_client):
         origin = "https://app.example.com"
@@ -123,13 +122,15 @@ class TestCorsAllowlist:
         )
         assert resp.status == 204
         assert resp.headers["Access-Control-Allow-Origin"] == origin
-        assert "Authorization" in resp.headers["Access-Control-Allow-Headers"]
-        assert "Idempotency-Key" in resp.headers["Access-Control-Allow-Headers"]
+        allow = {p.strip().lower() for p in resp.headers["Access-Control-Allow-Headers"].split(",")}
+        assert {"authorization", "content-type", "idempotency-key"} <= allow
+        methods = {
+            p.strip().upper() for p in resp.headers["Access-Control-Allow-Methods"].split(",")
+        }
+        assert "POST" in methods
 
     async def test_non_allowlisted_origin_still_rejected(self, aiohttp_client):
-        client = await aiohttp_client(
-            _make_app(cors_origins=["https://app.example.com"])
-        )
+        client = await aiohttp_client(_make_app(cors_origins=["https://app.example.com"]))
         resp = await client.get(
             "/thing",
             headers={
@@ -146,6 +147,17 @@ class TestNormalizeCorsOrigin:
     def test_strips_trailing_slash(self):
         assert normalize_cors_origin("https://app.example.com/") == "https://app.example.com"
 
+    def test_omits_default_https_port(self):
+        assert normalize_cors_origin("https://app.example.com:443") == "https://app.example.com"
+
+    def test_omits_default_http_port(self):
+        assert normalize_cors_origin("http://app.example.com:80") == "http://app.example.com"
+
+    def test_keeps_non_default_port(self):
+        assert (
+            normalize_cors_origin("https://app.example.com:8443") == "https://app.example.com:8443"
+        )
+
     def test_rejects_wildcard(self):
         with pytest.raises(ValueError, match="not allowed"):
             normalize_cors_origin("*")
@@ -153,3 +165,15 @@ class TestNormalizeCorsOrigin:
     def test_rejects_path(self):
         with pytest.raises(ValueError, match="path"):
             normalize_cors_origin("https://app.example.com/api")
+
+    def test_rejects_userinfo(self):
+        with pytest.raises(ValueError, match="userinfo"):
+            normalize_cors_origin("https://user:pass@app.example.com")
+
+    def test_rejects_invalid_port(self):
+        with pytest.raises(ValueError, match="invalid port"):
+            normalize_cors_origin("https://app.example.com:bad")
+
+    def test_rejects_empty_port(self):
+        with pytest.raises(ValueError, match="empty port"):
+            normalize_cors_origin("http://host:")

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,31 +1,38 @@
-"""Unit tests for the origin-check middleware (ported from ComfyUI core's
-create_origin_only_middleware).
-"""
+"""Unit tests for the origin-check and CORS middleware."""
 
 from __future__ import annotations
 
+import pytest
 from aiohttp import web
-from aiohttp.test_utils import TestClient, TestServer
 
-from comfy_api_proxy.middleware import origin_only_middleware
+from comfy_api_proxy.middleware import (
+    CORS_ALLOW_HEADERS,
+    attach_cors_prepare,
+    make_cors_middleware,
+    make_origin_only_middleware,
+    normalize_cors_origin,
+    origin_only_middleware,
+)
 
 
 async def _ok(request: web.Request) -> web.Response:
     return web.json_response({"ok": True})
 
 
-def _make_app() -> web.Application:
-    app = web.Application(middlewares=[origin_only_middleware])
+def _make_app(*, cors_origins: list[str] | None = None) -> web.Application:
+    origins = cors_origins or []
+    middlewares = []
+    if origins:
+        middlewares.append(make_cors_middleware(origins))
+    middlewares.append(
+        make_origin_only_middleware(origins) if origins else origin_only_middleware
+    )
+    app = web.Application(middlewares=middlewares)
+    if origins:
+        attach_cors_prepare(app)
     app.router.add_get("/thing", _ok)
+    app.router.add_route("OPTIONS", "/thing", _ok)
     return app
-
-
-async def _client():
-    app = _make_app()
-    server = TestServer(app)
-    client = TestClient(server)
-    await client.start_server()
-    return client
 
 
 class TestOriginOnlyMiddleware:
@@ -81,3 +88,68 @@ class TestOriginOnlyMiddleware:
             headers={"Host": "localhost:8189", "Origin": "http://localhost"},
         )
         assert resp.status == 200
+
+
+class TestCorsAllowlist:
+    async def test_allowlisted_cross_site_origin_is_allowed(self, aiohttp_client):
+        origin = "https://app.example.com"
+        client = await aiohttp_client(_make_app(cors_origins=[origin]))
+        resp = await client.get(
+            "/thing",
+            headers={
+                "Host": "127.0.0.1:8189",
+                "Origin": origin,
+                "Sec-Fetch-Site": "cross-site",
+            },
+        )
+        assert resp.status == 200
+        assert resp.headers["Access-Control-Allow-Origin"] == origin
+        assert resp.headers["Access-Control-Allow-Headers"] == CORS_ALLOW_HEADERS
+        assert "Retry-After" in resp.headers["Access-Control-Expose-Headers"]
+        assert "Content-Range" in resp.headers["Access-Control-Expose-Headers"]
+        assert "Accept-Ranges" in resp.headers["Access-Control-Expose-Headers"]
+
+    async def test_preflight_returns_204_with_cors_headers(self, aiohttp_client):
+        origin = "https://app.example.com"
+        client = await aiohttp_client(_make_app(cors_origins=[origin]))
+        resp = await client.options(
+            "/thing",
+            headers={
+                "Origin": origin,
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": "authorization,idempotency-key",
+                "Sec-Fetch-Site": "cross-site",
+            },
+        )
+        assert resp.status == 204
+        assert resp.headers["Access-Control-Allow-Origin"] == origin
+        assert "Authorization" in resp.headers["Access-Control-Allow-Headers"]
+        assert "Idempotency-Key" in resp.headers["Access-Control-Allow-Headers"]
+
+    async def test_non_allowlisted_origin_still_rejected(self, aiohttp_client):
+        client = await aiohttp_client(
+            _make_app(cors_origins=["https://app.example.com"])
+        )
+        resp = await client.get(
+            "/thing",
+            headers={
+                "Host": "127.0.0.1:8189",
+                "Origin": "https://evil.example",
+                "Sec-Fetch-Site": "cross-site",
+            },
+        )
+        assert resp.status == 403
+        assert "Access-Control-Allow-Origin" not in resp.headers
+
+
+class TestNormalizeCorsOrigin:
+    def test_strips_trailing_slash(self):
+        assert normalize_cors_origin("https://app.example.com/") == "https://app.example.com"
+
+    def test_rejects_wildcard(self):
+        with pytest.raises(ValueError, match="not allowed"):
+            normalize_cors_origin("*")
+
+    def test_rejects_path(self):
+        with pytest.raises(ValueError, match="path"):
+            normalize_cors_origin("https://app.example.com/api")


### PR DESCRIPTION
## Summary
- Opt-in `--enable-cors-header <origin>` (repeatable); `*` refused
- Preflight support for `Authorization` / `Idempotency-Key`; expose `Retry-After` / range headers
- Docs for hosted browser → local proxy; Node SDK remains Node-only (use `fetch`)

Fixes #19

## Test plan
- [x] `ruff check` / `ruff format --check`
- [x] `pytest` (151 passed)
- [ ] CI green
- [ ] Optional: browser smoke against allowlisted origin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in CORS support for hosted browser applications through repeatable origin allowlisting.
  * Enabled browser preflight requests and exposed relevant response headers for health, job, and streaming endpoints.
  * Preserved bearer authentication requirements for protected requests.

* **Documentation**
  * Added browser integration guidance, security details, CLI usage, and a browser `fetch` example.

* **Bug Fixes**
  * Invalid, wildcard, and path-based origins are now rejected with a clear CLI error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->