### PR TITLE
Emit bare, opaque asset IDs (drop the asset_ prefix)

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -569,7 +569,7 @@ components:
       required: true
       schema:
         type: string
-      example: asset_01JZV8Q3M7K2W9X0Y1Z2A3B4C5
+      example: 9f8a1c0d-2b3e-4f56-8a7b-1c2d3e4f5a6b
     BlakeHash:
       name: hash
       in: path
@@ -619,7 +619,7 @@ components:
       properties:
         id:
           type: string
-          example: asset_01JZV8Q3M7K2W9X0Y1Z2A3B4C5
+          example: 9f8a1c0d-2b3e-4f56-8a7b-1c2d3e4f5a6b
         hash:
           type: string
           nullable: true
@@ -823,7 +823,7 @@ components:
         id:
           type: string
           description: Asset UUID.
-          example: asset_01JZV9R4N8...
+          example: 9f8a1c0d-2b3e-4f56-...
         hash:
           type: string
           nullable: true
@@ -946,7 +946,7 @@ components:
       type: object
       description: "The typed asset-reference object placed inside workflow JSON where a\n\
         filename would normally go (documented here for tooling; it is not a\nrequest/response\
-        \ body itself):\n\n    {\"__type\": \"core/ASSET\",\n     \"info\": {\"id\": \"asset_...\"\
+        \ body itself):\n\n    {\"__type\": \"core/ASSET\",\n     \"info\": {\"id\": \"<asset-uuid>\"\
         , \"hash\": \"blake3:...\",\n              \"file_path\": \"photo.png\"}}\n\n`info.id`\
         \ (the asset UUID) is required in v1 and authoritative;\n`hash` and `file_path` are\
         \ optional staging/lookup hints and never\noverride a present `id`. A malformed reference\
@@ -967,7 +967,7 @@ components:
           properties:
             id:
               type: string
-              example: asset_01JZV8Q3M7K2W9X0Y1Z2A3B4C5
+              example: 9f8a1c0d-2b3e-4f56-8a7b-1c2d3e4f5a6b
             hash:
               type: string
               example: blake3:9f8a1c0d...

--- a/src/comfy_api_proxy/app.py
+++ b/src/comfy_api_proxy/app.py
@@ -259,7 +259,7 @@ class Proxy:
         payload_b64 = base64.urlsafe_b64encode(raw).decode().rstrip("=")
         tag = hmac.new(self._asset_secret, payload_b64.encode(), hashlib.sha256).digest()
         tag_b64 = base64.urlsafe_b64encode(tag).decode().rstrip("=")
-        return f"asset_{payload_b64}.{tag_b64}"
+        return f"{payload_b64}.{tag_b64}"
 
     def _decode_asset_id(self, asset_id: str) -> dict[str, str] | None:
         """Decode + verify a stateless asset id minted by ``_asset_id``.
@@ -267,12 +267,9 @@ class Proxy:
         Returns ``None`` (treated as "unknown/not found" by every caller)
         for anything that isn't a well-formed, correctly-signed id —
         including a syntactically valid but forged one, closing the
-        "any well-formed asset_<...> id is trusted" gap.
+        "any well-formed payload.tag id is trusted" gap.
         """
-        if not asset_id.startswith("asset_"):
-            return None
-        rest = asset_id[len("asset_") :]
-        payload_b64, sep, tag_b64 = rest.partition(".")
+        payload_b64, sep, tag_b64 = asset_id.partition(".")
         if not sep:
             return None
         try:

--- a/src/comfy_api_proxy/assets.py
+++ b/src/comfy_api_proxy/assets.py
@@ -51,7 +51,7 @@ def _now_iso() -> str:
 
 
 def new_asset_id() -> str:
-    return "asset_" + uuid.uuid4().hex
+    return str(uuid.uuid4())
 
 
 class AssetStore:

--- a/src/comfy_api_proxy/schemas/_generated.py
+++ b/src/comfy_api_proxy/schemas/_generated.py
@@ -26,7 +26,7 @@ class Asset(BaseModel):
     A user-owned record identified by a server-assigned UUID, backing an immutable blob whose content carries a server-computed blake3 hash. `hash` may be computed lazily: an asset record (and its retrievable bytes) can exist before its hash is filled in.
     """
 
-    id: str = Field(..., examples=['asset_01JZV8Q3M7K2W9X0Y1Z2A3B4C5'])
+    id: str = Field(..., examples=['9f8a1c0d-2b3e-4f56-8a7b-1c2d3e4f5a6b'])
     hash: str = Field(
         ...,
         description='`blake3:<hex>`; null while lazily computed.',
@@ -179,7 +179,7 @@ class FieldType(Enum):
 
 
 class Info(BaseModel):
-    id: str = Field(..., examples=['asset_01JZV8Q3M7K2W9X0Y1Z2A3B4C5'])
+    id: str = Field(..., examples=['9f8a1c0d-2b3e-4f56-8a7b-1c2d3e4f5a6b'])
     hash: str | None = Field(None, examples=['blake3:9f8a1c0d...'])
     file_path: str | None = Field(None, examples=['photo.png'])
 
@@ -191,7 +191,7 @@ class AssetReference(BaseModel):
     request/response body itself):
 
         {"__type": "core/ASSET",
-         "info": {"id": "asset_...", "hash": "blake3:...",
+         "info": {"id": "<asset-uuid>", "hash": "blake3:...",
                   "file_path": "photo.png"}}
 
     `info.id` (the asset UUID) is required in v1 and authoritative;
@@ -216,7 +216,7 @@ class Output(BaseModel):
     type: OutputType
     content_type: str = Field(..., examples=['image/png'])
     size_bytes: int = Field(..., examples=[1848320])
-    id: str = Field(..., description='Asset UUID.', examples=['asset_01JZV9R4N8...'])
+    id: str = Field(..., description='Asset UUID.', examples=['9f8a1c0d-2b3e-4f56-...'])
     hash: str = Field(..., description='`blake3:<hex>`; null until lazily computed.')
     url: AnyUrl
     url_expires_at: AwareDatetime

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -7,7 +7,13 @@ hash. These pin the store primitives directly.
 
 from __future__ import annotations
 
-from comfy_api_proxy.assets import AssetStore
+import uuid
+
+from comfy_api_proxy.assets import AssetStore, new_asset_id
+
+
+def test_new_asset_id_is_a_bare_uuid():
+    uuid.UUID(new_asset_id())  # raises if not a valid UUID; no "asset_" prefix
 
 
 def test_lookups_on_empty_store_return_none():

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -635,7 +635,9 @@ def test_legitimately_minted_asset_id_round_trips(stack):
     assert job["status"] == "succeeded", job.get("error")
     assert job["outputs"], "no outputs"
     legit_id = job["outputs"][0]["id"]
-    assert "." in legit_id  # signed `payload.tag` form, unlike bare-UUID upload ids
+    # Signed `payload.tag` form, unlike bare-UUID upload ids. Both halves are
+    # base64url, which has no ".", so exactly one separator is the whole shape.
+    assert legit_id.count(".") == 1
 
     status, _, content = stack.request("GET", job["outputs"][0]["url"])
     assert status == 200, content

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -657,10 +657,9 @@ def test_legitimately_minted_asset_id_round_trips(stack):
 
 def test_uploaded_asset_id_has_no_dot_and_still_resolves(stack):
     # Uploaded ids are bare UUIDs (assets.new_asset_id); signed job-output ids
-    # are `<payload_b64>.<tag_b64>`. _decode_asset_id tells the two apart by
-    # whether a "." is present (a bare UUID never contains one, so decoding
-    # falls through to the store lookup) — pin that a bare-UUID id can never
-    # be mistaken for the signed form.
+    # are `<payload_b64>.<tag_b64>`. Readers hit the store first and only
+    # decode on a miss, so what keeps the two apart is that a bare UUID never
+    # contains a "." and so can never decode as the signed form — pin that.
     status, asset, raw = stack.upload("cat.png", _PNG, "image/png", tags="input")
     assert status == 201, raw
     assert "." not in asset["id"]

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -636,7 +636,10 @@ def test_legitimately_minted_asset_id_round_trips(stack):
     assert job["outputs"], "no outputs"
     legit_id = job["outputs"][0]["id"]
     # Signed `payload.tag` form, unlike bare-UUID upload ids. Both halves are
-    # base64url, which has no ".", so exactly one separator is the whole shape.
+    # base64url, which has no ".", so exactly one separator is the whole shape —
+    # and the prefix carries no "." either, so the count alone would still admit
+    # the retired `asset_payload.tag`. Both assertions are load-bearing.
+    assert not legit_id.startswith("asset_")
     assert legit_id.count(".") == 1
 
     status, _, content = stack.request("GET", job["outputs"][0]["url"])

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -69,9 +69,11 @@ def test_job_and_output_urls_are_absolute(stack):
 
 
 def test_upload_asset_returns_asset_shape(stack):
+    import uuid as _uuid
+
     status, asset, raw = stack.upload("cat.png", _PNG, "image/png", tags="input")
     assert status == 201, raw
-    assert asset["id"].startswith("asset_")
+    _uuid.UUID(asset["id"])  # bare UUID, matching the shape other v2 surfaces emit
     assert asset["hash"].startswith("blake3:")
     assert asset["size_bytes"] == len(_PNG)
     assert asset["content_type"] == "image/png"
@@ -585,7 +587,7 @@ def test_normal_paths_still_succeed_after_traversal_fix(stack_with_models_dir):
 # Regression: forgeable stateless output asset ids.
 #
 # Before the fix, `_decode_asset_id` trusted any well-formed
-# `asset_<base64url(json)>` id — a hand-crafted one would let a client fetch
+# `<base64url(json)>.<tag>` id — a hand-crafted one would let a client fetch
 # an arbitrary filename/subfolder via /view (through get_asset_content), or
 # splice an attacker-chosen path into a submitted workflow (through
 # _resolve_asset_ref, reached via a core/ASSET reference). The ids are now
@@ -594,7 +596,7 @@ def test_normal_paths_still_succeed_after_traversal_fix(stack_with_models_dir):
 def test_forged_asset_id_rejected_by_content_fetch(stack):
     raw_payload = json.dumps({"f": "out.png", "s": "", "t": "output"}).encode()
     payload_b64 = base64.urlsafe_b64encode(raw_payload).decode().rstrip("=")
-    forged_id = f"asset_{payload_b64}.notarealsignature"
+    forged_id = f"{payload_b64}.notarealsignature"
 
     status, body, _ = stack.request("GET", f"/api/v2/assets/{forged_id}/content")
     assert status == 404, body
@@ -606,7 +608,7 @@ def test_forged_asset_id_rejected_by_content_fetch(stack):
 def test_forged_asset_id_rejected_by_workflow_resolution(stack):
     raw_payload = json.dumps({"f": "../../etc/passwd", "s": "", "t": "output"}).encode()
     payload_b64 = base64.urlsafe_b64encode(raw_payload).decode().rstrip("=")
-    forged_id = f"asset_{payload_b64}.notarealsignature"
+    forged_id = f"{payload_b64}.notarealsignature"
 
     workflow = {
         "1": {
@@ -633,7 +635,7 @@ def test_legitimately_minted_asset_id_round_trips(stack):
     assert job["status"] == "succeeded", job.get("error")
     assert job["outputs"], "no outputs"
     legit_id = job["outputs"][0]["id"]
-    assert legit_id.startswith("asset_")
+    assert "." in legit_id  # signed `payload.tag` form, unlike bare-UUID upload ids
 
     status, _, content = stack.request("GET", job["outputs"][0]["url"])
     assert status == 200, content
@@ -651,6 +653,21 @@ def test_legitimately_minted_asset_id_round_trips(stack):
     }
     status, body, raw = stack.request("POST", "/api/v2/jobs", {"workflow": workflow2})
     assert status == 201, raw
+
+
+def test_uploaded_asset_id_has_no_dot_and_still_resolves(stack):
+    # Uploaded ids are bare UUIDs (assets.new_asset_id); signed job-output ids
+    # are `<payload_b64>.<tag_b64>`. _decode_asset_id tells the two apart by
+    # whether a "." is present (a bare UUID never contains one, so decoding
+    # falls through to the store lookup) — pin that a bare-UUID id can never
+    # be mistaken for the signed form.
+    status, asset, raw = stack.upload("cat.png", _PNG, "image/png", tags="input")
+    assert status == 201, raw
+    assert "." not in asset["id"]
+
+    status, meta, raw = stack.request("GET", f"/api/v2/assets/{asset['id']}")
+    assert status == 200, raw
+    assert meta["id"] == asset["id"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The v2 contract dropped the `job_`/`asset_` prefix — IDs are opaque strings and each surface emits its store's native IDs. The proxy was the last one gluing a prefix on. **Breaking change**, made deliberately while clients are pre-1.0 rather than carrying a compatibility shim.

## The change

Two mint sites, still distinguishable:

- `new_asset_id()` (uploads) → bare UUID.
- Signed job-output IDs → `<payload>.<signature>`, losing only the prefix. `_decode_asset_id` partitions on the `.` instead of stripping a prefix first.

**The HMAC is untouched** — it was always what stops a client forging an ID that names an arbitrary file; the prefix never was. The two ID kinds stay apart because a bare UUID contains no `.` and so can never decode as the signed form. New test pins that.

**No migration needed.** Persisted IDs are an opaque `TEXT PRIMARY KEY`, so assets recorded before this keep resolving.

## Spec

Only the five affected examples, sourced from canonical's current values; models regenerated (zero drift). The vendored spec has unrelated drift from canonical since the last sync — left for its own PR, with `spec/VERSION` still pinned to the last real sync so the provenance stays accurate.

## Verified

166 tests pass. The forged-ID tests were updated to the new shape and still confirm rejection on both reachable paths (content fetch → 404, workflow resolution → 422).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Asset identifiers now use standard UUID format without the `asset_` prefix.
  - Output asset identifiers use a signed format while remaining valid for content retrieval and workflow references.
- **Bug Fixes**
  - Improved handling and validation of signed output identifiers.
  - Uploaded asset identifiers continue to resolve correctly.
- **Documentation**
  - Updated API examples and schema documentation to reflect the new identifier formats.
- **Tests**
  - Added coverage for UUID validity, signed output identifiers, and asset resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->