### PR TITLE
fix(demo): point the SDK at --base via COMFY_BASE_URL

### DIFF
--- a/demo/run_demo.py
+++ b/demo/run_demo.py
@@ -6,12 +6,15 @@ Usage:
     python demo/run_demo.py --base URL --key KEY   # against any v2 surface
 
 Only --base (and --key for cloud) change between surfaces; nothing else does.
-That is the whole point of the one-contract design.
+That is the whole point of the one-contract design. --base is passed to the
+SDK the way an integrator would set it: as the COMFY_BASE_URL environment
+variable, which is how the client picks a deployment.
 """
 
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -34,7 +37,8 @@ def main() -> int:
     ap.add_argument("--out", default="demo_output.png")
     args = ap.parse_args()
 
-    client = Comfy(args.base, api_key=args.key)
+    os.environ["COMFY_BASE_URL"] = args.base
+    client = Comfy(api_key=args.key)
     print(f"→ running a workflow against {args.base}")
     wf = client.workflows.from_json(WORKFLOW)
     job = client.run(wf)


### PR DESCRIPTION
The Python SDK no longer takes a base URL as a constructor argument — it reads `COMFY_BASE_URL` from the environment (`Comfy-Org/comfy-python-sdk#43`). `demo/run_demo.py` still called `Comfy(args.base, api_key=...)`, which raises `TypeError` against that SDK.

`--base` now sets `COMFY_BASE_URL` before constructing the client, which is also how an integrator configures it, so the demo keeps demonstrating the real usage.

Verified by running the demo end to end against `demo/fake_comfyui.py` + the proxy with the updated SDK checked out (job succeeded, output downloaded). Repo gates also pass: `ruff check`, `ruff format --check`, `mypy src/comfy_api_proxy`, `pytest` (166 passed).

Merge after the SDK PR lands and releases — the demo imports the SDK from a sibling checkout, so an older checkout would ignore the variable and target Comfy Cloud.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the demo’s server address is configured through the `COMFY_BASE_URL` environment variable.
  * Updated the demo setup to apply this configuration before initializing the client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->