### PR TITLE
feat: accept extra_data.extra_pnginfo instead of rejecting it

### DIFF
--- a/src/comfy_api_proxy/app.py
+++ b/src/comfy_api_proxy/app.py
@@ -639,18 +639,21 @@ class Proxy:
             return extras_err
 
         # Optional, typed, CLOSED extra_data (mirrors the v2 contract's
-        # `additionalProperties: false`): the only accepted key is
-        # `api_key_comfy_org` — the Comfy API key partner/API nodes authenticate
-        # with. It rides the upstream /prompt body verbatim and is never
-        # persisted or logged. Reject any other shape so the proxy stays
+        # `additionalProperties: false`): accepted keys are `api_key_comfy_org`
+        # (partner/API node auth) and `extra_pnginfo` (opt-in workflow embed
+        # for output PNG metadata). Rides the upstream /prompt body verbatim;
+        # never persisted or logged. Reject any other shape so the proxy stays
         # faithful to the contract instead of forwarding arbitrary data.
         extra_data = body.get("extra_data")
         if extra_data is not None:
-            if not isinstance(extra_data, dict) or set(extra_data) - {"api_key_comfy_org"}:
+            if not isinstance(extra_data, dict) or set(extra_data) - {
+                "api_key_comfy_org",
+                "extra_pnginfo",
+            }:
                 return _error(
                     400,
                     "invalid_request",
-                    "'extra_data' accepts only the 'api_key_comfy_org' field.",
+                    "'extra_data' accepts only 'api_key_comfy_org' and 'extra_pnginfo'.",
                 )
             # The schema types api_key_comfy_org as a (non-nullable) string, so a
             # present-but-null or non-string value is rejected — not forwarded.
@@ -662,6 +665,22 @@ class Proxy:
                     "invalid_request",
                     "'extra_data.api_key_comfy_org' must be a string.",
                 )
+            # extra_pnginfo is itself closed, with a single `workflow` field
+            # that carries the graph verbatim (contents not otherwise checked).
+            if "extra_pnginfo" in extra_data:
+                pnginfo = extra_data["extra_pnginfo"]
+                if not isinstance(pnginfo, dict) or set(pnginfo) - {"workflow"}:
+                    return _error(
+                        400,
+                        "invalid_request",
+                        "'extra_data.extra_pnginfo' accepts only the 'workflow' field.",
+                    )
+                if "workflow" in pnginfo and not isinstance(pnginfo["workflow"], dict):
+                    return _error(
+                        400,
+                        "invalid_request",
+                        "'extra_data.extra_pnginfo.workflow' must be an object.",
+                    )
 
         missing: list[str] = []
         resolved_workflow = self._rewrite_asset_refs(workflow, missing)
@@ -718,11 +737,11 @@ class Proxy:
             "prompt_id": job_id,
             "client_id": job_id,
         }
-        # Forward extra_data (partner-node auth) verbatim to ComfyUI's /prompt.
-        # We never store it on the job row (see self._jobs below), and the
-        # client-facing job response is built field-by-field from an allow-list
-        # (_job), so the credential can't surface through this proxy regardless
-        # of what ComfyUI's /history returns.
+        # Forward extra_data (partner-node auth, workflow embed) verbatim to
+        # ComfyUI's /prompt. We never store it on the job row (see self._jobs
+        # below), and the client-facing job response is built field-by-field
+        # from an allow-list (_job), so it can't surface through this proxy
+        # regardless of what ComfyUI's /history returns.
         if extra_data:
             payload["extra_data"] = extra_data
         try:

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -253,6 +253,88 @@ def test_extra_data_rejects_uncontracted_shapes(stack):
         assert body["error"]["code"] == "invalid_request", raw
 
 
+def test_extra_pnginfo_forwarded_to_prompt(stack):
+    # extra_data.extra_pnginfo.workflow (opt-in debug embed) must ride the
+    # upstream /prompt body verbatim, same as api_key_comfy_org.
+    graph = {"1": {"class_type": "SaveImage", "inputs": {}}}
+    status, job, raw = stack.request(
+        "POST",
+        "/api/v2/jobs",
+        {"workflow": {"1": {}}, "extra_data": {"extra_pnginfo": {"workflow": graph}}},
+    )
+    assert status == 201, raw
+    present, value = _fake_prompt_extra_data(stack, job["id"])
+    assert present and value == {"extra_pnginfo": {"workflow": graph}}
+
+
+def test_extra_pnginfo_and_api_key_together_forwarded(stack):
+    # Both accepted keys can be supplied on the same request.
+    graph = {"1": {}}
+    status, job, raw = stack.request(
+        "POST",
+        "/api/v2/jobs",
+        {
+            "workflow": {"1": {}},
+            "extra_data": {
+                "api_key_comfy_org": "comfyui-secret",
+                "extra_pnginfo": {"workflow": graph},
+            },
+        },
+    )
+    assert status == 201, raw
+    present, value = _fake_prompt_extra_data(stack, job["id"])
+    assert present and value == {
+        "api_key_comfy_org": "comfyui-secret",
+        "extra_pnginfo": {"workflow": graph},
+    }
+
+
+def test_extra_pnginfo_workflow_omitted_accepted_and_forwarded(stack):
+    # workflow is optional inside extra_pnginfo (parity with the canonical
+    # contract, where only extra_pnginfo's key set is closed, not required).
+    # An empty extra_pnginfo must still be accepted and forwarded verbatim,
+    # not silently dropped like an empty top-level extra_data.
+    status, job, raw = stack.request(
+        "POST", "/api/v2/jobs", {"workflow": {"1": {}}, "extra_data": {"extra_pnginfo": {}}}
+    )
+    assert status == 201, raw
+    present, value = _fake_prompt_extra_data(stack, job["id"])
+    assert present and value == {"extra_pnginfo": {}}
+
+
+def test_extra_pnginfo_rejects_uncontracted_shapes(stack):
+    # extra_pnginfo is itself closed: only a `workflow` object is accepted.
+    for bad in (
+        {"workflow": {"1": {}}, "surprise": 1},  # unknown key inside extra_pnginfo
+        {"workflow": "not-an-object"},  # workflow must be an object
+        {"workflow": None},  # present-but-null
+        "not-an-object",  # extra_pnginfo itself must be an object
+        None,  # extra_pnginfo itself present-but-null
+    ):
+        status, body, raw = stack.request(
+            "POST",
+            "/api/v2/jobs",
+            {"workflow": {"1": {}}, "extra_data": {"extra_pnginfo": bad}},
+        )
+        assert status == 400, f"{bad!r} -> {raw!r}"
+        assert body["error"]["code"] == "invalid_request", raw
+
+
+def test_extra_data_still_rejects_unknown_top_level_key_with_pnginfo_present(stack):
+    # Adding extra_pnginfo to the accepted set must not loosen the top-level
+    # object into "accept anything" — an undeclared sibling key still 400s.
+    status, body, raw = stack.request(
+        "POST",
+        "/api/v2/jobs",
+        {
+            "workflow": {"1": {}},
+            "extra_data": {"extra_pnginfo": {"workflow": {"1": {}}}, "surprise": 1},
+        },
+    )
+    assert status == 400, raw
+    assert body["error"]["code"] == "invalid_request", raw
+
+
 def test_idempotency_key_reuse_ignores_differing_api_key(stack):
     # api_key_comfy_org is excluded from the idempotency comparison: a resubmit
     # under the same key is rejected as reuse even with a different api_key —


### PR DESCRIPTION
The proxy allowed exactly one `extra_data` key and returned **400** for anything else. So an SDK client that opted into embedding its workflow in output metadata got a hard error against a self-hosted ComfyUI — a broken feature on a supported path, not a silent no-op.

```mermaid
flowchart LR
  subgraph B["Before"]
    direction LR
    S1["SDK<br/>embed_workflow=True"] --> P1["proxy"]
    P1 --x E1["400 invalid_request"]
  end
  subgraph A["After"]
    direction LR
    S2["SDK<br/>embed_workflow=True"] --> P2["proxy"]
    P2 -- "extra_data verbatim" --> C2["ComfyUI /prompt"]
    C2 --> N2["PNG: workflow chunk"]
  end
```

## What changed

`extra_data` now also accepts `extra_pnginfo` — closed, with a single optional `workflow` object — matching the v2 contract. Undeclared keys are still rejected at both levels. Forwarding already passed `extra_data` verbatim, so it needed no change; tests assert the body the upstream actually received, not just the status code.

## Contract parity

`workflow` is **optional**, not required. That's the case most likely to drift from the other implementations of this contract, so a test pins that `{"extra_pnginfo": {}}` is accepted and forwarded — a future "reject if `workflow` missing" check by false analogy with `api_key_comfy_org` would fail it.

## Reviewer notes

- Needs the matching server-side contract change, landing separately.
- `spec/openapi.yaml` is untouched by design (synced one-way), so the code briefly accepts a field the vendored spec doesn't declare. This does **not** trip the spec-drift gate — the `extra_data` validation is hand-rolled and never goes through the generated models. Verified by running that job.
- `extra_data` reaches neither the persisted job record nor `GET /jobs/{id}`, so the new field can't surface there.
- Not in this PR: a dedicated size cap on `extra_pnginfo.workflow` (today bounded only by the app-wide ~101 MB limit, consistent with the existing `workflow` field).

`ruff`, `mypy`, `pytest` (171 passed), spec-drift and leak-scan all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)