### PR TITLE
feat: trace an output back to its job and the job's workflow

### DIFF
--- a/docs/batch-workloads.md
+++ b/docs/batch-workloads.md
@@ -29,9 +29,9 @@ ring (`MAXIMUM_HISTORY_SIZE = 10000`, days at a typical rate), which is why the
 read-through matters: jobs in between still resolve upstream.
 
 **The directory grows without bound.** Every accepted submit stores its full
-workflow graph, which nothing reads back (kept for forensics) and nothing
-prunes — order 10 MB/day per proxy at ~1 000 jobs/day with a large graph. Age
-out the state file on your own schedule if you run one proxy for months.
+workflow graph — read back by `GET /jobs/{id}/workflow`, otherwise unpruned —
+order 10 MB/day per proxy at ~1 000 jobs/day with a large graph. Age out the
+state file on your own schedule if you run one proxy for months.
 
 This is separate from ComfyUI's own SQLite (`--database-url`, used by the
 optional `--enable-assets` catalog of models/files/tags). ComfyUI does not

--- a/src/comfy_api_proxy/app.py
+++ b/src/comfy_api_proxy/app.py
@@ -5,6 +5,10 @@ What each v2 operation maps to on ComfyUI:
 
   * ``POST /api/v2/jobs``        → resolve ``core/ASSET`` refs, then ``POST /prompt``
   * ``GET  /api/v2/jobs/{id}``   → ``/history/{id}`` (+ ``/queue`` for queued/running)
+  * ``GET  /api/v2/jobs/{id}/workflow`` → the proxy's own record of the
+                                   resolved (executed) graph, always
+                                   ``format: "api"`` (not ComfyUI's /history —
+                                   see ``_job_workflow``)
   * ``POST /api/v2/jobs/{id}/cancel`` → ``POST /api/jobs/{id}/cancel`` (atomic)
   * ``GET  /api/v2/jobs/{id}/events``  → live ``/ws`` translated to SSE
   * ``POST /api/v2/assets``      → ``POST /upload/image`` (inputs) or direct
@@ -399,6 +403,7 @@ class Proxy:
                             "hash": None,
                             "url": f"{base}/api/v2/assets/{aid}/content",
                             "url_expires_at": _iso(now + _RETENTION),
+                            "job_id": job_id,
                         }
                     )
         return out
@@ -438,6 +443,32 @@ class Proxy:
 
     def _knows_job(self, job_id: str) -> bool:
         return bool(self._job_meta(job_id))
+
+    def _job_workflow(self, job_id: str) -> dict[str, Any] | None:
+        """The API-format graph ``job_id`` actually ran with (core/ASSET refs
+        already resolved to filenames — see ``resolved_workflow`` in
+        ``submit``), or None if this proxy can no longer produce it (never
+        seen, evicted from the in-memory window, or --state-dir isn't in
+        use).
+
+        Deliberately NOT read from ComfyUI's own /history: even though it
+        holds the same resolved graph, it carries this proxy's own
+        extra_data (partner API key) alongside it, which our own record
+        never does — reading from history would risk leaking that credential.
+
+        A record reloaded into memory by ``_load_state`` (via ``store.load_jobs``)
+        has no "workflow" key at all — that startup path deliberately skips
+        hydrating it (see ``StateStore.load_jobs``) — so its presence, not
+        just the meta dict's presence, decides whether to trust memory or
+        fall through to the store's dedicated column read.
+        """
+        meta = self._jobs.get(job_id)
+        if meta is not None and "workflow" in meta:
+            workflow = meta["workflow"]
+            return workflow if isinstance(workflow, dict) else None
+        if self._store is not None:
+            return self._store.get_job_workflow(job_id)
+        return None
 
     def _job(self, job_id: str, state: dict[str, Any], base: str) -> dict[str, Any]:
         meta = self._job_meta(job_id)
@@ -745,7 +776,10 @@ class Proxy:
             # Unknown outcome — ComfyUI may already hold the prompt. HOLD the
             # key (do not release) so a same-key retry can't double-submit.
             return _error(503, "upstream_unreachable", "Could not reach ComfyUI to submit the job.")
-        self._remember_job(job_id, workflow=workflow, metadata=metadata, priority=priority)
+        # Store the RESOLVED graph (core/ASSET refs replaced with filenames) —
+        # what actually ran, matching GET /jobs/{id}/workflow's contract and
+        # Cloud's own behavior — not the as-submitted `workflow`.
+        self._remember_job(job_id, workflow=resolved_workflow, metadata=metadata, priority=priority)
         base = _external_base(request)
         return web.json_response(
             self._job(job_id, {"status": "queued", "outputs": [], "outputs_reused": False}, base),
@@ -824,6 +858,20 @@ class Proxy:
         if state["status"] == "unknown" and not self._knows_job(job_id):
             return _error(404, "not_found", f"No job {job_id}.")
         return web.json_response(self._job(job_id, state, base))
+
+    async def get_job_workflow(self, request: web.Request) -> web.Response:
+        job_id = request.match_info["id"]
+        if not _valid_job_id(job_id):
+            return _error(404, "not_found", f"No job {job_id}.")
+        workflow = self._job_workflow(job_id)
+        if workflow is None:
+            return _error(404, "not_found", f"No recoverable workflow for job {job_id}.")
+        # `format` discriminates save-format (authoring) vs. api-format
+        # (executed) graphs — Cloud can return either depending on whether a
+        # job pins a workflow version; this proxy has no version concept and
+        # always returns the executed graph, but sets the field regardless so
+        # a client sees the same response shape against either backend.
+        return web.json_response({"workflow": workflow, "format": "api"})
 
     async def cancel_job(self, request: web.Request) -> web.Response:
         job_id = request.match_info["id"]
@@ -1163,18 +1211,21 @@ class Proxy:
         if decoded is not None:
             now = _now()
             ctype = mimetypes.guess_type(decoded["f"])[0] or "application/octet-stream"
-            return web.json_response(
-                {
-                    "id": asset_id,
-                    "hash": None,
-                    "size_bytes": 0,
-                    "content_type": ctype,
-                    "file_path": decoded["f"],
-                    "created_at": _iso(now),
-                    "url": f"{base}/api/v2/assets/{asset_id}/content",
-                    "url_expires_at": _iso(now + _RETENTION),
-                }
-            )
+            body: dict[str, Any] = {
+                "id": asset_id,
+                "hash": None,
+                "size_bytes": 0,
+                "content_type": ctype,
+                "file_path": decoded["f"],
+                "created_at": _iso(now),
+                "url": f"{base}/api/v2/assets/{asset_id}/content",
+                "url_expires_at": _iso(now + _RETENTION),
+            }
+            # "j" is absent on ids minted before per-job-scoping (see
+            # _decode_asset_id) — omit rather than fabricate a job_id for those.
+            if "j" in decoded:
+                body["job_id"] = decoded["j"]
+            return web.json_response(body)
         return _error(404, "not_found", "Unknown asset id.")
 
     async def get_asset_content(self, request: web.Request) -> web.StreamResponse:
@@ -1408,6 +1459,7 @@ def make_app(
             web.post("/api/v2/jobs", proxy.submit),
             web.get("/api/v2/jobs", proxy.list_jobs),
             web.get("/api/v2/jobs/{id}", proxy.get_job),
+            web.get("/api/v2/jobs/{id}/workflow", proxy.get_job_workflow),
             web.post("/api/v2/jobs/{id}/cancel", proxy.cancel_job),
             web.get("/api/v2/jobs/{id}/events", proxy.job_events),
             # assets

--- a/src/comfy_api_proxy/persist.py
+++ b/src/comfy_api_proxy/persist.py
@@ -171,6 +171,17 @@ class StateStore:
             ).fetchone()
         return None if row is None else _job_record(row)
 
+    def get_job_workflow(self, job_id: str) -> dict[str, Any] | None:
+        """The resolved (executed) workflow graph for one job, or None. Separate from
+        ``get_job`` (which deliberately skips this column) so the common
+        job-lookup path stays cheap; only GET /jobs/{id}/workflow pays for it."""
+        with self._lock:
+            row = self._conn.execute("SELECT workflow FROM jobs WHERE id = ?", (job_id,)).fetchone()
+        if row is None:
+            return None
+        workflow = json.loads(row["workflow"])
+        return workflow if isinstance(workflow, dict) else None
+
     # -- idempotency ---------------------------------------------------------
     def claim_idempotency(self, key: str, *, claimed_at: str, job_id: str | None = None) -> bool:
         """Return True if the key was newly claimed; False if already present."""

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -300,6 +300,119 @@ def test_get_unknown_job_404(stack):
     assert body["error"]["code"] == "not_found"
 
 
+# ---------------------------------------------------------------------------
+# GET /api/v2/jobs/{id}/workflow
+# ---------------------------------------------------------------------------
+def test_get_job_workflow_round_trip_no_asset_refs(stack):
+    # No core/ASSET refs to resolve, so the executed graph happens to equal
+    # the submitted one here — this only proves the basic round trip + the
+    # `format` discriminator; test_get_job_workflow_returns_resolved_graph
+    # below proves it's actually the EXECUTED graph, not the submitted one.
+    workflow = {"9": {"class_type": "SaveImage", "inputs": {"images": ["1", 0]}}}
+    status, job, raw = stack.request("POST", "/api/v2/jobs", {"workflow": workflow})
+    assert status == 201, raw
+    status, body, raw = stack.request("GET", f"/api/v2/jobs/{job['id']}/workflow")
+    assert status == 200, raw
+    assert body == {"workflow": workflow, "format": "api"}
+
+
+def test_get_job_workflow_returns_resolved_graph_not_submitted(stack):
+    # The endpoint must return the EXECUTED graph (core/ASSET refs already
+    # resolved to the filename ComfyUI received), not the as-submitted one —
+    # matching what actually ran, per the contract's parity requirement.
+    _, asset, _ = stack.upload("cat.png", _PNG, "image/png", tags="input")
+    submitted = {
+        "1": {
+            "class_type": "LoadImage",
+            "inputs": {"image": {"__type": "core/ASSET", "info": {"id": asset["id"]}}},
+        },
+        "9": {"class_type": "SaveImage", "inputs": {"images": ["1", 0]}},
+    }
+    status, job, raw = stack.request("POST", "/api/v2/jobs", {"workflow": submitted})
+    assert status == 201, raw
+
+    status, body, raw = stack.request("GET", f"/api/v2/jobs/{job['id']}/workflow")
+    assert status == 200, raw
+    assert body["format"] == "api"
+    returned = body["workflow"]
+    assert returned != submitted, "returned the as-submitted graph, not the executed one"
+    # The core/ASSET reference object is gone, replaced by the plain filename
+    # string ComfyUI actually received.
+    assert isinstance(returned["1"]["inputs"]["image"], str)
+    assert returned["9"] == submitted["9"]  # untouched node is unchanged
+
+
+def test_get_job_workflow_unknown_job_404(stack):
+    status, body, _ = stack.request("GET", "/api/v2/jobs/job_ghost/workflow")
+    assert status == 404
+    assert body["error"]["code"] == "not_found"
+
+
+def test_get_job_workflow_rejects_non_uuid_id(stack):
+    status, body, _ = stack.request("GET", "/api/v2/jobs/..%2F..%2Ffree/workflow")
+    assert status == 404, body
+    assert body["error"]["code"] == "not_found"
+
+
+def test_get_job_workflow_never_includes_extra_data(stack):
+    # extra_data (partner API key) must never surface through this endpoint,
+    # even though it rode the upstream /prompt call for this same job.
+    status, job, raw = stack.request(
+        "POST",
+        "/api/v2/jobs",
+        {"workflow": {"1": {}}, "extra_data": {"api_key_comfy_org": "comfyui-secret"}},
+    )
+    assert status == 201, raw
+    status, body, raw = stack.request("GET", f"/api/v2/jobs/{job['id']}/workflow")
+    assert status == 200, raw
+    assert body == {"workflow": {"1": {}}, "format": "api"}
+    assert "extra_data" not in body
+    assert "comfyui-secret" not in json.dumps(body)
+
+
+def test_get_job_workflow_survives_restart_via_state_dir(make_stack, tmp_path):
+    # A job the in-memory window has forgotten (proxy restarted) must still
+    # resolve through --state-dir, mirroring get_job()'s own read-through.
+    state_dir = tmp_path / "state"
+    stack, cleanup = make_stack(tmp_path, state_dir=str(state_dir))
+    try:
+        workflow = {"9": {"class_type": "SaveImage", "inputs": {"images": ["1", 0]}}}
+        status, job, raw = stack.request("POST", "/api/v2/jobs", {"workflow": workflow})
+        assert status == 201, raw
+    finally:
+        cleanup()
+
+    stack2, cleanup2 = make_stack(tmp_path, state_dir=str(state_dir))
+    try:
+        status, body, raw = stack2.request("GET", f"/api/v2/jobs/{job['id']}/workflow")
+        assert status == 200, raw
+        assert body == {"workflow": workflow, "format": "api"}
+    finally:
+        cleanup2()
+
+
+def test_get_job_workflow_404_without_state_dir_after_restart(make_stack, tmp_path):
+    # Without --state-dir, a restart drops the in-memory record entirely — the
+    # endpoint must say so (404), not fabricate an answer from ComfyUI's
+    # resolved history (which wouldn't equal what was submitted anyway).
+    stack, cleanup = make_stack(tmp_path)
+    try:
+        workflow = {"9": {"class_type": "SaveImage", "inputs": {"images": ["1", 0]}}}
+        status, job, raw = stack.request("POST", "/api/v2/jobs", {"workflow": workflow})
+        assert status == 201, raw
+        comfyui_port = stack.comfyui_port
+    finally:
+        cleanup()
+
+    stack2, cleanup2 = make_stack(tmp_path, comfyui_port=comfyui_port)
+    try:
+        status, body, raw = stack2.request("GET", f"/api/v2/jobs/{job['id']}/workflow")
+        assert status == 404, raw
+        assert body["error"]["code"] == "not_found"
+    finally:
+        cleanup2()
+
+
 def test_sse_stream_delivers_progress_preview_and_terminal(stack):
     # A hang job so the SSE bridge connects while it is still running and
     # exercises the WS-driven progress/preview path, then we cancel it to
@@ -672,6 +785,37 @@ def test_uploaded_asset_id_has_no_dot_and_still_resolves(stack):
     status, meta, raw = stack.request("GET", f"/api/v2/assets/{asset['id']}")
     assert status == 200, raw
     assert meta["id"] == asset["id"]
+
+
+async def test_legacy_asset_id_without_job_scoping_omits_job_id():
+    # An id minted before the per-job-scoping change has no "j" in its signed
+    # payload (see _decode_asset_id) — get_asset() must not fabricate a
+    # job_id for those. Every other test mints ids the normal way (always
+    # job-scoped), so this is the only coverage that would catch a regression
+    # that emits job_id unconditionally. Signed by hand with the running
+    # Proxy's own secret (proxy._asset_id always includes "j" now), mirroring
+    # the forged-id tests above but with a genuine signature.
+    import base64
+    import hashlib
+    import hmac
+    import json
+
+    from aiohttp.test_utils import make_mocked_request
+
+    from comfy_api_proxy.app import Proxy
+
+    proxy = Proxy("http://127.0.0.1:1")  # never contacted: get_asset needs no upstream call
+    raw_payload = json.dumps({"f": "out.png", "s": "", "t": "output"}).encode()
+    payload_b64 = base64.urlsafe_b64encode(raw_payload).decode().rstrip("=")
+    tag = hmac.new(proxy._asset_secret, payload_b64.encode(), hashlib.sha256).digest()
+    tag_b64 = base64.urlsafe_b64encode(tag).decode().rstrip("=")
+    legacy_id = f"{payload_b64}.{tag_b64}"
+
+    req = make_mocked_request("GET", f"/api/v2/assets/{legacy_id}", match_info={"id": legacy_id})
+    resp = await proxy.get_asset(req)
+    assert resp.status == 200
+    asset = json.loads(resp.body)
+    assert "job_id" not in asset, asset
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -161,8 +161,25 @@ def test_submit_poll_download_roundtrip(servers):
     assert job["status"] == "succeeded", f"job did not succeed: {job.get('error')}"
     assert job["outputs"], "job succeeded but produced no outputs"
 
-    # 3. Download the output content and assert it is a real, non-empty PNG.
+    # 3. The output identifies the job that produced it (callers correlate
+    # per output file, not per job, so this is the load-bearing assertion).
     output = job["outputs"][0]
+    assert output["job_id"] == job_id, output
+
+    # 4. Fetching the same output standalone (by its asset id, not nested in
+    # the job response) still carries job_id.
+    status, asset, raw = _request("GET", f"{PROXY_BASE}/api/v2/assets/{output['id']}")
+    assert status == 200, f"get_asset failed ({status}): {raw!r}"
+    assert asset["job_id"] == job_id, asset
+
+    # 5. Fetch the job's workflow: the executed graph (WORKFLOW has no
+    #    core/ASSET refs to resolve, so it equals what was submitted here),
+    #    tagged with the "api" format discriminator.
+    status, body, raw = _request("GET", f"{PROXY_BASE}/api/v2/jobs/{job_id}/workflow")
+    assert status == 200, f"get_job_workflow failed ({status}): {raw!r}"
+    assert body == {"workflow": WORKFLOW, "format": "api"}
+
+    # 6. Download the output content and assert it is a real, non-empty PNG.
     status, _parsed, content = _request("GET", output["url"])
     assert status == 200, f"download failed ({status})"
     assert content, "downloaded output is empty"


### PR DESCRIPTION
Callers process results **per output file, not per job**, and had no way to get from an output back to what produced it.

```mermaid
flowchart LR
  subgraph B["Before"]
    direction LR
    O1["output file"] -.->|"no link"| X["prompt_id<br/>+ /ws filtering<br/>+ /history lookup"]
    X --> J1["job"]
    J1 -.->|"no way to ask"| W1["workflow"]
  end
  subgraph A["After"]
    direction LR
    O2["output file"] -->|"job_id"| J2["job"]
    J2 -->|"GET /jobs/{id}/workflow"| W2["workflow"]
  end
```

## Two additions

**`job_id`** on outputs and on the standalone `GET /assets/{id}` lookup. The standalone path is the one that matters — a caller holding an output file doesn't already know the job. Ids minted before per-job scoping carry none, so the field is omitted rather than fabricated.

**`GET /jobs/{id}/workflow`**, returning the **executed** graph — what was actually POSTed to ComfyUI, with `core/ASSET` references resolved. A `format` discriminator is included so a client never guesses which graph shape it holds; this proxy has no workflow-version concept, so it's always `"api"`.

## Two decisions worth a reviewer's eye

**Source: the proxy's own job record, not ComfyUI's `/history`.** History carries `extra_data`, which can hold a partner API key — the proxy's record never did, so there's no redaction step to get wrong. No new persistence either: the `workflow` column was already being written.

**404 over a stale answer.** For a job the proxy no longer remembers (outside the in-memory window, no `--state-dir`), it returns 404 rather than reaching into ComfyUI for something approximate.

## Proven end to end

`tests/test_smoke.py` drives the proxy over its own HTTP surface with only the standard library. One real submit → poll → succeed round trip now asserts `job_id` on the nested output, fetches the output standalone by asset id and asserts it there too, then fetches the workflow and asserts the graph and discriminator — before the existing PNG check.

Also covered: the endpoint returns the **resolved** graph (asserted by submitting a `core/ASSET` reference and checking it comes back rewritten), `extra_data` never appears in the response, survival across a `--state-dir` restart, and 404 without one.

## On the spec

`spec/openapi.yaml` is untouched — vendored and synced one-way from the canonical contract, where these have now landed. This repo's copy is pinned at `2026-07-16` and predates them, so syncing it is a separate change; nothing here depends on it. Verified rather than assumed that this is safe: neither `Output` nor `Asset` is a closed object, and the drift job only regenerates models from the vendored spec, so both it and `test_schema_conformance.py` pass unchanged.

`ruff`, `mypy`, spec-drift, and the internal-leak scan clean; **174 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an endpoint to retrieve the resolved workflow associated with a job.
  * Job outputs now include their originating job ID, including when retrieving assets directly.
  * Resolved workflows retain asset references as filenames for easier reuse.

* **Bug Fixes**
  * Invalid or unavailable job workflows now return appropriate not-found responses.
  * Legacy output asset IDs continue to use their existing response format.

* **Documentation**
  * Documented workflow retrieval and persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
