### PR TITLE
ci: bump pypa/gh-action-pypi-publish to v1.14.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -126,7 +126,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: dist/
           skip-existing: true # idempotent re-runs: no-op instead of erroring if this version is already up
@@ -151,7 +151,7 @@ jobs:
           path: dist/
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: dist/
           repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
## What

Bumps both `pypa/gh-action-pypi-publish` pins in `publish.yml` from v1.12.4 to v1.14.2 (`dc37677b2e1c63e2034f94d8a5b11f265b73ba33`).

## Why

The v0.1.6 release build succeeded but the upload step failed:

```
Checking dist/comfy_api_proxy-0.1.6-py3-none-any.whl:
ERROR InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

v1.12.4 bundles `packaging==24.2`, which only recognizes metadata versions through 2.4. A hatchling released since v0.1.5 now emits `Metadata-Version: 2.5`, and `build-system.requires` pins no hatchling version, so the same source started producing metadata the pinned uploader can't parse. v1.14.2 bundles `packaging==26.2` / `twine==7.0.0`, which accept 2.5.

The `build` job's `twine check` passed because it `pip install`s a current twine — only the uploader saw the stale parser.

## Scope and risk

Two lines. All three inputs we pass (`packages-dir`, `repository-url`, `skip-existing`) are still valid at v1.14.2. Pins stay full-SHA with the trailing version comment, per the zizmor rule. Nothing reached PyPI on the failed run, so `0.1.6` is still unclaimed and the existing release can be re-published once this lands.

## Verified

Diffed the action's `requirements/runtime.txt` and `action.yml` at both pinned SHAs to confirm the packaging bump and input compatibility. The publish path itself can only be exercised by a real release.